### PR TITLE
Require bootstrap.php if exists, to load all necessary .env files

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -202,6 +202,13 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         }
 
         $this->kernel = new $this->kernelClass($this->config['environment'], $this->config['debug']);
+
+        $bootstrapFile = $this->kernel->getProjectDir() . '/config/bootstrap.php';
+        if (file_exists($bootstrapFile)) {
+            $_ENV['APP_ENV'] = $this->config['environment'];
+            require $bootstrapFile;
+        }
+
         $this->kernel->boot();
 
         if ($this->config['cache_router'] === true) {


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/issues/5411

Must be released as 2.0.0