### PR TITLE
Update Symfony.php

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -498,6 +498,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         }
 
         $realCount = $profile->getCollector('swiftmailer')->getMessageCount();
+        $realCount += count($profile->getCollector('mailer')->getEvents()->getMessages());
         if ($expectedCount === null) {
             $this->assertGreaterThan(0, $realCount);
         } else {


### PR DESCRIPTION
Fixing `seeEmailIsSent()` for [Symfony Mailer](https://symfony.com/doc/master/mailer.html)

How did I figure it out (=Symfony internals):
[`mailer_debug.php`](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_debug.php) sends the [`MessageDataCollector`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Mailer/DataCollector/MessageDataCollector.php) to [`mailer.html.twig`](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig#L9), which shows that the number of `events.messages` is the thing to look for.

I'm just adding this number to the number returned by the SwiftMailer Collector.

Limitations (=TODO):
* I have both SwiftMailer and Symfony Mailer installed - don't know what happens if you only have one (or none)
* I didn't add any tests - don't know how to do that