### PR TITLE
Added amLoggedInAs function (and more)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2011 Michael Bodnarchuk and contributors
+Copyright (c) 2011-2020 Michael Bodnarchuk and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "codeception/module-phpbrowser": "^1.0",
         "codeception/module-rest": "^1.2",
         "codeception/module-sequence": "^1.0",
-        "vlucas/phpdotenv": "^4.1"
+        "vlucas/phpdotenv": "^3.6 | ^4.1"
     },
     "autoload":{
         "classmap": ["src/"]

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name":"codeception/module-symfony",
     "description":"Codeception module for Symfony framework",
     "keywords":["codeception", "symfony"],
-    "homepage":"http://codeception.com/",
+    "homepage":"https://codeception.com/",
     "type":"library",
     "license":"MIT",
     "authors":[
@@ -13,17 +13,17 @@
     "minimum-stability": "RC",
     "require": {
         "php": ">=5.6.0 <8.0",
-        "codeception/lib-innerbrowser": "^1.0",
+        "codeception/lib-innerbrowser": "^1.3",
         "codeception/codeception": "^4.0"
     },
     "require-dev": {
         "codeception/util-robohelpers": "dev-master",
-        "codeception/module-asserts": "dev-master | ^1.0",
-        "codeception/module-doctrine2": "dev-master | ^1.0",
-        "codeception/module-phpbrowser": "dev-master | ^1.0",
-        "codeception/module-rest": "dev-master | ^1.0",
-        "codeception/module-sequence": "dev-master | ^1.0",
-        "vlucas/phpdotenv": "^3.6"
+        "codeception/module-asserts": "^1.3",
+        "codeception/module-doctrine2": "^1.0",
+        "codeception/module-phpbrowser": "^1.0",
+        "codeception/module-rest": "^1.2",
+        "codeception/module-sequence": "^1.0",
+        "vlucas/phpdotenv": "^4.1"
     },
     "autoload":{
         "classmap": ["src/"]

--- a/documentation.md
+++ b/documentation.md
@@ -1,24 +1,4 @@
 # Symfony
-## Installation
-
-If you use Codeception installed using composer, install this module with the following command:
-
-```
-composer require --dev codeception/module-symfony
-```
-
-Alternatively, you can enable `Symfony` module in suite configuration file and run
- 
-```
-codecept init upgrade4
-```
-
-This module was bundled with Codeception 2 and 3, but since version 4 it is necessary to install it separately.   
-Some modules are bundled with PHAR files.  
-Warning. Using PHAR file and composer in the same project can cause unexpected errors.  
-
-## Description
-
 
 
 This module uses Symfony Crawler and HttpKernel to emulate requests and test response.

--- a/documentation.md
+++ b/documentation.md
@@ -235,6 +235,23 @@ $I->amOnPage('/register');
  * `param string` $page
 
 
+### amLoggedInAs
+
+Login with the given UserInterface.
+
+```php
+<?php
+$user = $I->grabEntityFromRepository(User::class, [
+    'email' => 'john_doe@gmail.com'
+]);
+$I->amLoggedInAs($user);
+```
+
+ * `param UserInterface` $user
+ * `param string` $firewallName
+ * `param null` $firewallContext
+
+
 ### amOnRoute
  
 Opens web page using route name and parameters.

--- a/documentation.md
+++ b/documentation.md
@@ -1,4 +1,24 @@
 # Symfony
+## Installation
+
+If you use Codeception installed using composer, install this module with the following command:
+
+```
+composer require --dev codeception/module-symfony
+```
+
+Alternatively, you can enable `Symfony` module in suite configuration file and run
+ 
+```
+codecept init upgrade4
+```
+
+This module was bundled with Codeception 2 and 3, but since version 4 it is necessary to install it separately.   
+Some modules are bundled with PHAR files.  
+Warning. Using PHAR file and composer in the same project can cause unexpected errors.  
+
+## Description
+
 
 
 This module uses Symfony Crawler and HttpKernel to emulate requests and test response.
@@ -18,6 +38,8 @@ This module uses Symfony Crawler and HttpKernel to emulate requests and test res
 * debug: true - turn on/off debug mode
 * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
 * rebootable_client: 'true' - reboot client's kernel before each request
+* mailer: 'symfony_mailer' - choose the mailer used by your application
+* guard: 'false' - Specifies if Guard component is used as authentication system
 
 #### Example (`functional.suite.yml`) - Symfony 4 Directory Structure
 
@@ -38,6 +60,8 @@ This module uses Symfony Crawler and HttpKernel to emulate requests and test res
 * debug: true - turn on/off debug mode
 * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
 * rebootable_client: 'true' - reboot client's kernel before each request
+* mailer: 'swiftmailer' - choose the mailer used by your application
+* guard: 'false' - Specifies if Guard component is used as authentication system
 
 #### Example (`functional.suite.yml`) - Symfony 3 Directory Structure
 
@@ -58,6 +82,8 @@ This module uses Symfony Crawler and HttpKernel to emulate requests and test res
 * em_service: 'doctrine.orm.entity_manager' - use the stated EntityManager to pair with Doctrine Module.
 * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
 * rebootable_client: 'true' - reboot client's kernel before each request
+* mailer: 'swiftmailer' - choose the mailer used by your application
+* guard: 'false' - Specifies if Guard component is used as authentication system
 
 ### Example (`functional.suite.yml`) - Symfony 2.x Directory Structure
 
@@ -220,6 +246,24 @@ Authenticates user for HTTP_AUTH
  * `param` $password
 
 
+### amLoggedInAs
+ 
+Login with the given UserInterface.
+That UserInterface object must have a persistent identifier.
+
+```php
+<?php
+$user = $I->grabEntityFromRepository(User::class, [
+'email' => 'john_doe@gmail.com'
+]);
+$I->amLoggedInAs($user);
+```
+
+ * `param UserInterface` $user
+ * `param string` $firewallName
+ * `param null` $firewallContext
+
+
 ### amOnPage
  
 Opens the page for the given relative URI.
@@ -233,23 +277,6 @@ $I->amOnPage('/register');
 ```
 
  * `param string` $page
-
-
-### amLoggedInAs
-
-Login with the given UserInterface.
-
-```php
-<?php
-$user = $I->grabEntityFromRepository(User::class, [
-    'email' => 'john_doe@gmail.com'
-]);
-$I->amLoggedInAs($user);
-```
-
- * `param UserInterface` $user
- * `param string` $firewallName
- * `param null` $firewallContext
 
 
 ### amOnRoute

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,15 @@
-# Codeception module for Symfony framework
+# Codeception Module Symfony
+
+A Codeception module for Symfony framework.
 
 [![Build Status](https://travis-ci.org/Codeception/module-symfony.svg?branch=master)](https://travis-ci.org/Codeception/module-symfony)
 
 ## Installation
 
 ```
-composer require --dev "codeception/module-symfony"
+composer require "codeception/module-symfony" --dev
 ```
 
 ## Documentation
 
-<a href="documentation.md">Look at documentation.md file</a>
+[Look at documentation.md file](/documentation.md)

--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -2,9 +2,9 @@
 namespace Codeception\Lib\Connector;
 
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
+use Symfony\Component\HttpKernel\Kernel;
 
-//Alias for Symfony < 4.3
-if (!class_exists('Symfony\Component\HttpKernel\HttpKernelBrowser') && class_exists('Symfony\Component\HttpKernel\Client')) {
+if (Kernel::VERSION_ID < 40300) {
     class_alias('Symfony\Component\HttpKernel\Client', 'Symfony\Component\HttpKernel\HttpKernelBrowser');
 }
 

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -38,6 +38,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
  * * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
  * * rebootable_client: 'true' - reboot client's kernel before each request
  * * mailer: 'symfony_mailer' - choose the mailer used by your application
+ * * guard: 'false' - Specifies if Guard component is used as authentication system
  *
  * #### Example (`functional.suite.yml`) - Symfony 4 Directory Structure
  *
@@ -59,6 +60,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
  * * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
  * * rebootable_client: 'true' - reboot client's kernel before each request
  * * mailer: 'swiftmailer' - choose the mailer used by your application
+ * * guard: 'false' - Specifies if Guard component is used as authentication system
  *
  * #### Example (`functional.suite.yml`) - Symfony 3 Directory Structure
  *
@@ -80,6 +82,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
  * * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
  * * rebootable_client: 'true' - reboot client's kernel before each request
  * * mailer: 'swiftmailer' - choose the mailer used by your application
+ * * guard: 'false' - Specifies if Guard component is used as authentication system
  *
  * ### Example (`functional.suite.yml`) - Symfony 2.x Directory Structure
  *
@@ -773,6 +776,22 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         return [$this->config['kernel_class']];
     }
 
+    /**
+     * Login with the given UserInterface.
+     * That UserInterface object must have a persistent identifier.
+     *
+     * ```php
+     * <?php
+     * $user = $I->grabEntityFromRepository(User::class, [
+     * 'email' => 'john_doe@gmail.com'
+     * ]);
+     * $I->amLoggedInAs($user);
+     * ```
+     *
+     * @param UserInterface $user
+     * @param string $firewallName
+     * @param null $firewallContext
+     */
     public function amLoggedInAs(UserInterface $user, $firewallName = 'main', $firewallContext = null)
     {
         $container = $this->_getContainer();

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -796,6 +796,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     {
         $container = $this->_getContainer();
         if (!$container->has('session')) {
+            $this->fail("Symfony container doesn't have 'session' service");
             return;
         }
 

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -4,19 +4,20 @@ namespace Codeception\Module;
 
 use Codeception\Configuration;
 use Codeception\Exception\ModuleException;
-use Codeception\Lib\Framework;
 use Codeception\Exception\ModuleRequireException;
 use Codeception\Lib\Connector\Symfony as SymfonyConnector;
+use Codeception\Lib\Framework;
 use Codeception\Lib\Interfaces\DoctrineProvider;
 use Codeception\Lib\Interfaces\PartedModule;
-use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Finder\SplFileInfo;
-use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * This module uses Symfony Crawler and HttpKernel to emulate requests and test response.
@@ -116,8 +117,8 @@ use Symfony\Component\Console\Output\BufferedOutput;
  */
 class Symfony extends Framework implements DoctrineProvider, PartedModule
 {
-    public const SWIFTMAILER = 'swiftmailer';
-    public const SYMFONY_MAILER = 'symfony_mailer';
+    const SWIFTMAILER = 'swiftmailer';
+    const SYMFONY_MAILER = 'symfony_mailer';
 
     private static $possibleKernelClasses = [
         'AppKernel', // Symfony Standard
@@ -138,7 +139,8 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         'cache_router' => false,
         'em_service' => 'doctrine.orm.entity_manager',
         'rebootable_client' => true,
-        'mailer' => self::SWIFTMAILER
+        'mailer' => self::SWIFTMAILER,
+        'guard' => false
     ];
 
     /**
@@ -769,5 +771,32 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         }
 
         return [$this->config['kernel_class']];
+    }
+
+    public function amLoggedInAs(UserInterface $user, $firewallName = 'main', $firewallContext = null)
+    {
+        $container = $this->_getContainer();
+        if (!$container->has('session')) {
+            return;
+        }
+
+        $session = $this->grabService('session');
+
+        if ($this->config['guard']) {
+            $token = new PostAuthenticationGuardToken($user, $firewallName, $user->getRoles());
+        } else {
+            $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
+        }
+
+        if ($firewallContext) {
+            $session->set('_security_'.$firewallContext, serialize($token));
+        } else {
+            $session->set('_security_'.$firewallName, serialize($token));
+        }
+
+        $session->save();
+
+        $cookie = new Cookie($session->getName(), $session->getId());
+        $this->client->getCookieJar()->set($cookie);
     }
 }

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -237,7 +237,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         parent::_after($test);
     }
 
-    public function onReconfigure($settings = [])
+    protected function onReconfigure($settings = [])
     {
 
         parent::_beforeSuite($settings);


### PR DESCRIPTION
Related to [Codeception issue 5699](https://github.com/Codeception/Codeception/issues/5699)

 - [x] Added new function: `amLoggedInAs` to login a user. 

<details>
  <summary>Click to see added function.</summary>

```php
    public function amLoggedInAs(UserInterface $user, $firewallName = 'main', $firewallContext = null)
    {
        $container = $this->_getContainer();
        if (!$container->has('session')) {
            $this->fail("Symfony container doesn't have 'session' service");
            return;
        }

        $session = $this->grabService('session');

        if ($this->config['guard']) {
            $token = new PostAuthenticationGuardToken($user, $firewallName, $user->getRoles());
        } else {
            $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
        }

        if ($firewallContext) {
            $session->set('_security_'.$firewallContext, serialize($token));
        } else {
            $session->set('_security_'.$firewallName, serialize($token));
        }

        $session->save();

        $cookie = new Cookie($session->getName(), $session->getId());
        $this->client->getCookieJar()->set($cookie);
    }
```

</details>

```php
        $user = $I->grabEntityFromRepository(User::class, ['email' => 'john_doe@gmail.com']);
        $I->amLoggedInAs($user);
```

- [x] Added [guard](https://symfony.com/components/Guard) config, in case the authentication system is based on it.
```diff
    public $config = [
        'app_path' => 'app',
        'var_path' => 'app',
        'kernel_class' => null,
        'environment' => 'test',
        'debug' => true,
        'cache_router' => false,
        'em_service' => 'doctrine.orm.entity_manager',
        'rebootable_client' => true,
        'mailer' => self::SWIFTMAILER,
+        'guard' => false
    ];
```

- [x] Updated dependencies (as far as possible).
- [x] Updated docs.
- [x] Improved compatibility logic:
```diff
- //Alias for Symfony < 4.3
- if (!class_exists('Symfony\Component\HttpKernel\HttpKernelBrowser') && class_exists('Symfony\Component\HttpKernel\Client')) {
+ if (Kernel::VERSION_ID < 40300) {
    class_alias('Symfony\Component\HttpKernel\Client', 'Symfony\Component\HttpKernel\HttpKernelBrowser');
}
```