### PR TITLE
Added logout function

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -747,6 +747,15 @@ $I->haveHttpHeader('Client&#95;Id', 'Codeception');
 Invalidate previously cached routes.
 
 
+### logout
+ 
+Invalidate the current session.
+```php
+<?php
+$I->logout();
+```
+
+
 ### makeHtmlSnapshot
  
 Saves current page's HTML into a temprary file.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -788,6 +788,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         }
 
         if (!$container->has('session')) {
+            $this->fail("Symfony container doesn't have 'session' service");
             return;
         }
         $session = $this->grabService('session');


### PR DESCRIPTION
Just like the Laravel module, the Symfony Module should have this function. 

This time the implementation required something more elaborate than just calling `session->invalidate()` since although the session was removed the cookies were kept in `Symfony\Component\BrowserKit\AbstractBrowser` instance (`$this->client`).

It asks for the two cookies by default, but additionally it asks for the current session since they may not be the same.



