### PR TITLE
Added seeInSession function

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -1092,6 +1092,21 @@ $I->seeInFormFields('//form[@id=my-form]', $form);
  * `param` $params
 
 
+### seeInSession
+ 
+Assert that a session attribute exists.
+
+```php
+<?php
+$I->seeInSession('attrib');
+$I->seeInSession('attrib', 'value');
+```
+
+ * `param string` $attrib
+ * `param mixed|null` $value
+ * `return` void
+
+
 ### seeInSource
  
 Checks that the current page contains the given string in its

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -770,4 +770,36 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
         return [$this->config['kernel_class']];
     }
+
+    /**
+     * Assert that a session attribute exists.
+     *
+     * ```php
+     * <?php
+     * $I->seeInSession('attrib');
+     * $I->seeInSession('attrib', 'value');
+     * ```
+     *
+     * @param string $attrib
+     * @param mixed|null $value
+     * @return void
+     */
+    public function seeInSession($attrib, $value = null)
+    {
+        $container = $this->_getContainer();
+
+        if (!$container->has('session')) {
+            return;
+        }
+
+        $session = $this->grabService('session');
+
+        if (! $session->has($attrib)) {
+            $this->fail("No session attribute with name '$attrib'");
+        }
+
+        if (null !== $value) {
+            $this->assertEquals($value, $session->get($attrib));
+        }
+    }
 }

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -789,6 +789,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $container = $this->_getContainer();
 
         if (!$container->has('session')) {
+            $this->fail("Symfony container doesn't have 'session' service");
             return;
         }
 


### PR DESCRIPTION
Just like in Laravel module, the Symfony Module should also have this function.

In this case the logic [is very similar](https://github.com/Codeception/module-laravel5/blob/bd2c604e8aa02d2b24737de01c6716473e8db96c/src/Codeception/Module/Laravel5.php#L610), the name of the parameters has been updated to be in accordance with the [Symfony documentation](https://symfony.com/doc/current/components/http_foundation/sessions.html).

As soon as this can be merged I will proceed to implement the `seeSessionHasValues` function to assert multiple attributes / values.