### PR TITLE
Added amOnAction function

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -220,6 +220,21 @@ Authenticates user for HTTP_AUTH
  * `param` $password
 
 
+### amOnAction
+ 
+Opens web page by action name
+
+``` php
+<?php
+$I->amOnAction('PostController::index');
+$I->amOnAction('HomeController');
+$I->amOnAction('ArticleController', ['slug' => 'lorem-ipsum']);
+```
+
+ * `param string` $action
+ * `param array` $params
+
+
 ### amOnPage
  
 Opens the page for the given relative URI.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -790,6 +790,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $container = $this->_getContainer();
 
         if (!$container->has('router')) {
+            $this->fail("Symfony container doesn't have 'router' service");
             return;
         }
 


### PR DESCRIPTION
Just like the Laravel Module, the Symfony Module should have this function.

In this case, the logic [is quite different](https://github.com/Codeception/module-laravel5/blob/bd2c604e8aa02d2b24737de01c6716473e8db96c/src/Codeception/Module/Laravel5.php#L503) compared to the Laravel Module logic and at the same time **_it's simpler_** since it does not require calling other functions in the same module.

I don't entirely agree with the name of this function, if it were up to me I would call it `amOnController`, but being consistent and maintaining the same API between modules is one of my goals here.