### PR TITLE
Added seeAuthentication function

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -866,6 +866,20 @@ For checking the raw source code, use `seeInSource()`.
  * `param array|string` $selector optional
 
 
+### seeAuthentication
+ 
+Checks that a user is authenticated.
+You can check users logged in with the option 'remember me' passing true as parameter.
+
+```php
+<?php
+$I->seeAuthentication();
+$I->seeAuthentication(true);
+```
+
+ * `param bool` $remembered
+
+
 ### seeCheckboxIsChecked
  
 Checks that the specified checkbox is checked.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -770,4 +770,43 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
         return [$this->config['kernel_class']];
     }
+
+    /**
+     * Checks that a user is authenticated.
+     * You can check users logged in with the option 'remember me' passing true as parameter.
+     *
+     * ```php
+     * <?php
+     * $I->seeAuthentication();
+     * $I->seeAuthentication(true);
+     * ```
+     *
+     * @param bool $remembered
+     */
+    public function seeAuthentication($remembered = false)
+    {
+        $container = $this->_getContainer();
+
+        if (!$container->has('security.helper')) {
+            $this->fail("Symfony container doesn't have 'security.helper' service");
+            return;
+        }
+
+        $security = $this->grabService('security.helper');
+
+        $user = $security->getUser();
+
+        if (!$user) {
+            $this->fail('There is no user in session');
+            return;
+        }
+
+        if ($remembered) {
+            $role = 'IS_AUTHENTICATED_REMEMBERED';
+        } else {
+            $role = 'IS_AUTHENTICATED_FULLY';
+        }
+
+        $this->assertTrue($security->isGranted($role), 'There is no authenticated user');
+    }
 }


### PR DESCRIPTION
Added function that checks if a user is logged in, [based on Symfony documentation](https://symfony.com/doc/current/security.html#checking-to-see-if-a-user-is-logged-in-is-authenticated-fully) and corresponding roles.


The Laravel module [has a function](https://github.com/Codeception/module-laravel5/blob/bd2c604e8aa02d2b24737de01c6716473e8db96c/src/Codeception/Module/Laravel5.php#L792) with the same name, however the concept of `Guard` in Symfony has a very different implementation than Laravel.