### PR TITLE
Added seeCurrentActionIs function

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -896,6 +896,19 @@ $I->seeCookie('PHPSESSID');
  * `param array` $params
 
 
+### seeCurrentActionIs
+ 
+Checks that current page matches action
+
+``` php
+<?php
+$I->seeCurrentActionIs('PostController::index');
+$I->seeCurrentActionIs('HomeController');
+```
+
+ * `param string` $action
+
+
 ### seeCurrentRouteIs
  
 Checks that current url matches route.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -770,4 +770,41 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
         return [$this->config['kernel_class']];
     }
+
+    /**
+     * Checks that current page matches action
+     *
+     * ``` php
+     * <?php
+     * $I->seeCurrentActionIs('PostController::index');
+     * $I->seeCurrentActionIs('HomeController');
+     * ```
+     *
+     * @param string $action
+     */
+    public function seeCurrentActionIs($action)
+    {
+        $container = $this->_getContainer();
+
+        if (!$container->has('router')) {
+            $this->fail("Symfony container doesn't have 'router' service");
+            return;
+        }
+
+        $router = $this->grabService('router');
+
+        $routes = $router->getRouteCollection()->getIterator();
+
+        foreach ($routes as $route) {
+            $controller = basename($route->getDefault('_controller'));
+            if ($controller === $action) {
+                $request = $this->client->getRequest();
+                $currentAction = basename($request->attributes->get('_controller'));
+
+                $this->assertEquals($currentAction, $action, "Current action is '$currentAction'.");
+                return;
+            }
+        }
+        $this->fail("Action '$action' does not exist");
+    }
 }


### PR DESCRIPTION
the Laravel module [has this function](https://github.com/Codeception/module-laravel5/blob/bd2c604e8aa02d2b24737de01c6716473e8db96c/src/Codeception/Module/Laravel5.php#L523), so the symfony module should also have it.

Verifies if the action exists and if **_it exists_** compares it with the current action. If, on the contrary, the action **_does not exist_**, it fails and displays a message about it.