### PR TITLE
Improved seeEmailIsSent error message

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -497,8 +497,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             case self::SWIFTMAILER:
                 if (!$profile->hasCollector('swiftmailer')) {
                     $this->fail(
-                        'Emails can\'t be tested without SwiftMailer connector.
-                    If you are using Symfony Mailer define mailer: "symfony_mailer" in Symfony module config.'
+                        "Emails can't be tested without SwiftMailer connector.\nIf you are using Symfony Mailer, set this in your `functional.suite.yml`: `mailer: 'symfony_mailer'`"
                     );
                 }
                 break;


### PR DESCRIPTION
Adding an even more descriptive comment - follow-up of https://github.com/Codeception/module-symfony/pull/9/commits/2f8467151b5228335cc167263a98b5e6386573b3

The indentation of the code is preserved in the displayed message, so it looked like this:
```
 Fail  Emails can't be tested without SwiftMailer connector.
                    If you are using Symfony Mailer define mailer: "symfony_mailer" in Symfony module config.
```
I hope the `\n` works better :-)