### PR TITLE
Added grabRepository function

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -1101,4 +1101,62 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $cookie = new Cookie($session->getName(), $session->getId());
         $this->client->getCookieJar()->set($cookie);
     }
+
+    /**
+     * Grab a Doctrine entity repository.
+     * Works with objects, entities, repositories, and repository interfaces.
+     *
+     * ```php
+     * <?php
+     * $I->grabRepository($user);
+     * $I->grabRepository(User::class);
+     * $I->grabRepository(UserRepository::class);
+     * $I->grabRepository(UserRepositoryInterface::class);
+     * ```
+     *
+     * @param object|string $mixed
+     * @return \Doctrine\ORM\EntityRepository|null
+     */
+    public function grabRepository($mixed)
+    {
+        $entityRepoClass = '\Doctrine\ORM\EntityRepository';
+        $isNotARepo = function () use ($mixed) {
+            $this->fail(
+                sprintf("'%s' is not an entity repository", $mixed)
+            );
+        };
+        $getRepo = function () use ($mixed, $entityRepoClass, $isNotARepo) {
+            if (!$repo = $this->grabService($mixed)) return null;
+            if (!$repo instanceof $entityRepoClass) {
+                $isNotARepo();
+                return null;
+            }
+            return $repo;
+        };
+
+        if (interface_exists($mixed)) {
+            return $getRepo();
+        }
+
+        if (is_object($mixed)) {
+            $mixed = get_class($mixed);
+        }
+
+        if (!is_string($mixed) || !class_exists($mixed) ) {
+            $isNotARepo();
+            return null;
+        }
+
+        if (is_subclass_of($mixed, $entityRepoClass)){
+            return $getRepo();
+        }
+
+        $em = $this->_getEntityManager();
+        if ($em->getMetadataFactory()->isTransient($mixed)) {
+            $isNotARepo();
+            return null;
+        }
+
+        return $em->getRepository($mixed);
+    }
 }


### PR DESCRIPTION
`$I->grabRepository` significantly improves the readability of the tests that communicate with the database :)

as mentioned in the docblock, it works with:

- [x] Entity objects,
```php
$userRepository = $I->grabRepository($user);
```
- [x] Entity classes,
```php
$userRepository = $I->grabRepository(User::class);
```
- [x] Repository classes,
```php
$userRepository = $I->grabRepository(UserRepository::class);
```
- [x] or even Custom Interfaces that have been implemented in a repository.
```php
$userRepository = $I->grabRepository(UserRepositoryInterface::class);
```

It also includes validations in case of incorrect data and fails the test showing a corresponding error message.

@Naktibalda

