### PR TITLE
Allow vlucas/phpdotenv v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "codeception/module-phpbrowser": "^1.0",
         "codeception/module-rest": "^1.2",
         "codeception/module-sequence": "^1.0",
-        "vlucas/phpdotenv": "^3.6 | ^4.1"
+        "vlucas/phpdotenv": "^3.6 | ^4.1 | ^5.2"
     },
     "autoload":{
         "classmap": ["src/"]


### PR DESCRIPTION
Codeception [now supports](https://github.com/Codeception/Codeception/pull/6015) `vlucas/phpdotenv` v5, so now it can be allowed here too.