### PR TITLE
Added submitSymfonyForm function

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -966,6 +966,35 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
+     * Submits the given Symfony Form on the page, with the given form values.
+     * If you customized the CSS selectors or field names use ->submitForm() instead.
+     *
+     * ```php
+     * <?php
+     * $I->submitSymfonyForm('login_form', [
+     *     '[email]'    => 'john_doe@gmail.com',
+     *     '[password]' => 'secretForest'
+     * ]);
+     * ```
+     *
+     * @param string $name
+     * @param string[] $fields
+     */
+    public function submitSymfonyForm($name, $fields)
+    {
+        $selector = sprintf('form[name=%s]', $name);
+
+        $params = [];
+        foreach ($fields as $key => $value) {
+            $fixedKey = sprintf('%s%s', $name, $key);
+            $params[$fixedKey] = $value;
+        }
+        $button = sprintf('%s_submit', $name);
+
+        $this->submitForm($selector, $params, $button);
+    }
+
+    /**
      * Check that the current user has a role
      *
      * ```php

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -966,8 +966,10 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
-     * Submits the given Symfony Form on the page, with the given form values.
-     * If you customized the CSS selectors or field names use ->submitForm() instead.
+     * Submit a form specifying the form name only once.
+     *
+     * Use this function instead of $I->submitForm() to avoid repeating the form name in the field selectors.
+     * If you customized the names of the field selectors use $I->submitForm() for full control.
      *
      * ```php
      * <?php


### PR DESCRIPTION
While testing forms in Symfony it is very common to have to repeat the form name in different places in the method to comply with **the Symfony naming format**:
```php
	$I->submitForm('form[name={form_name}]', [
		'{form_name}[{field_key}]' => '{field_value}',
		'{form_name}[{field_key}]' => '{field_value}'
	], '{form_name}_submit');
```
However this **ruins the readability of the test** and makes the code much more verbose:
```php
	$I->submitForm('form[name=user_update_password_form]', [
		'user_update_password_form[oldPassword]'      => '123456',
		'user_update_password_form[password][first]'  => '654321',
		'user_update_password_form[password][second]' => '654321'
	], 'user_update_password_form_submit');
```
That is why i write this function that allows you to take advantage of the fact that the naming format **is always the same**, and allows you to *simplify* the action of submitting a form:
```php
	$I->submitSymfonyForm('user_update_password_form', [
		'[oldPassword]'      => '123456',
		'[password][first]'  => '654321',
		'[password][second]' => '654321'
	]);
```
For the few who **do** edit this format in their applications and create something super-custom there is always the option to use the base `->submitForm()` function, so this is basically a shortcut alias function.

The improvement in readability is significant.