### PR TITLE
Added availability check functions

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -476,6 +476,45 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
+     * Goes to a page and check that it can be accessed.
+     *
+     * ```php
+     * <?php
+     * $I->seePageIsAvailable('/dashboard');
+     * ```
+     *
+     * @param string $url
+     */
+    public function seePageIsAvailable($url)
+    {
+        $this->amOnPage($url);
+        $this->seeResponseCodeIsSuccessful();
+        $this->seeInCurrentUrl($url);
+    }
+
+    /**
+     * Goes to a page and check that it redirects to another.
+     *
+     * ```php
+     * <?php
+     * $I->seePageRedirectsTo('/admin', '/login');
+     * ```
+     *
+     * @param string $page
+     * @param string $redirectsTo
+     */
+    public function seePageRedirectsTo($page, $redirectsTo)
+    {
+        $this->client->followRedirects(false);
+        $this->amOnPage($page);
+        $this->assertTrue(
+            $this->client->getResponse()->isRedirection()
+        );
+        $this->client->followRedirect();
+        $this->seeInCurrentUrl($redirectsTo);
+    }
+
+    /**
      * Checks if the desired number of emails was sent.
      * If no argument is provided then at least one email must be sent to satisfy the check.
      * The email is checked using Symfony's profiler, which means:


### PR DESCRIPTION
`$I->seePageIsAvailable()` allows to do in a line of code what is normally done like this: [[See source](https://github.com/symfony/demo/blob/bb3b1834079e1af8a65786b48415c8147fc7ee10/tests/Controller/DefaultControllerTest.php#L52)]
```php
    public function testPublicBlogPost(): void
    {
        $client = static::createClient();
        $blogPost = $client->getContainer()->get('doctrine')->getRepository(Post::class)->find(1);
        $client->request('GET', sprintf('/en/blog/posts/%s', $blogPost->getSlug()));

        $this->assertResponseIsSuccessful();
    }
```

while `$I->seePageRedirectsTo()` allows to do in a line of code what is normally done in this way: [[See source](https://github.com/symfony/demo/blob/bb3b1834079e1af8a65786b48415c8147fc7ee10/tests/Controller/DefaultControllerTest.php#L69)]

```php
    public function testSecureUrls(string $url): void
    {
        $client = static::createClient();
        $client->request('GET', $url);

        $this->assertResponseRedirects(
            'http://localhost/en/login',
            Response::HTTP_FOUND,
            sprintf('The %s secure URL redirects to the login form.', $url)
        );
    }
```