### PR TITLE
Remove php 5.6 and Symfony 2.8 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 # Exclude files that don't need to be present in packages (so they're not downloaded by Composer)
 /.gitattributes  export-ignore
 /.gitignore      export-ignore
-/Robofile.php    export-ignore
 /*.md            export-ignore
 /*.yml           export-ignore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,31 +22,15 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
-        symfony: [2.8, 3.4, 4, 5]
+        php: [7.0, 7.1, 7.2, 7.3, 7.4]
+        symfony: [3.4, 4, 5]
         exclude:
-          - php: 7.0
-            symfony: 2.8
-          - php: 7.1
-            symfony: 2.8
-          - php: 7.2
-            symfony: 2.8
-          - php: 7.3
-            symfony: 2.8
-          - php: 7.4
-            symfony: 2.8
-          - php: 5.6
-            symfony: 3.4
           - php: 7.3
             symfony: 3.4
           - php: 7.4
             symfony: 3.4
-          - php: 5.6
-            symfony: 4
           - php: 7.0
             symfony: 4
-          - php: 5.6
-            symfony: 5
           - php: 7.0
             symfony: 5
           - php: 7.1
@@ -62,14 +46,6 @@ jobs:
         php-version: ${{ matrix.php }}
         extensions: pdo, mysql, sqlite
         coverage: none
-
-    - name: Checkout Symfony 2.8 Sample
-      if: matrix.symfony == 2.8
-      uses: actions/checkout@v2
-      with:
-        repository: Codeception/symfony-demo
-        path: framework-tests
-        ref: 2.1
 
     - name: Checkout Symfony 3.4 Sample
       if: matrix.symfony == 3.4
@@ -113,13 +89,6 @@ jobs:
         composer require "symfony/browser-kit=~${{ matrix.symfony }}" --no-update --ignore-platform-reqs
         composer install --prefer-dist --no-progress --no-interaction --no-suggest
 
-    - name: Database Symfony 2.8
-      if: matrix.symfony == 2.8
-      run: |
-        php app/console doctrine:schema:create -n --env test
-        php app/console doctrine:fixtures:load -n --env test
-      working-directory: framework-tests
-
     - name: Database Symfony 3.4
       if: matrix.symfony == 3.4
       run: |
@@ -131,11 +100,5 @@ jobs:
         php bin/console doctrine:schema:update --force -n
       working-directory: framework-tests
 
-    - name: Run test suite Symfony > 2.8
-      if: matrix.symfony != 2.8
+    - name: Run test suite Symfony
       run: php vendor/bin/codecept run functional -c framework-tests
-
-    - name: Run test suite Symfony 2.8
-      if: matrix.symfony == 2.8
-      run: php vendor/bin/codecept run functional -c framework-tests/src/AppBundle
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,37 +5,23 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 env:
   global:
     - TEST_PATH='framework-tests'
     - SYMFONY_DEPRECATIONS_HELPER=weak
   matrix:
-    - VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
     - VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
     - VERSION=4 TEST_REPO='https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit
     - VERSION=5 TEST_REPO='-b symfony5 https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit
 matrix:
   exclude:
-    - php: 7.0
-      env: VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
-    - php: 7.1
-      env: VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
-    - php: 7.2
-      env: VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
-    - php: 7.3
-      env: VERSION=2.8 TEST_REPO='-b 2.1 https://github.com/Codeception/symfony-demo.git' SUITES=functional TEST_PATH=framework-tests/src/AppBundle
-    - php: 5.6
-      env: VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
-    - php: 7.0
-      env: VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
     - php: 7.3
       env: VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
-    - php: 5.6
-      env: VERSION=4 TEST_REPO='https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit
+    - php: 7.4
+      env: VERSION=3.4 TEST_REPO='--recurse-submodules https://github.com/Naktibalda/codeception-symfony-tests'
     - php: 7.0
       env: VERSION=4 TEST_REPO='https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit
-    - php: 5.6
-      env: VERSION=5 TEST_REPO='-b symfony5 https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit
     - php: 7.0
       env: VERSION=5 TEST_REPO='-b symfony5 https://github.com/Codeception/symfony-demo.git' SUITES=functional,unit
     - php: 7.1
@@ -61,8 +47,6 @@ install:
   - COMPOSER_MEMORY_LIMIT=-1 composer update -d framework-tests --no-dev --prefer-dist --no-interaction
 before_script:
   - mysql -e "create database symfony_test;"
-  - '[[ "$VERSION" != "2.8" ]] || php framework-tests/app/console doctrine:schema:create -n --env test'
-  - '[[ "$VERSION" != "2.8" ]] || php framework-tests/app/console doctrine:fixtures:load -n --env test'
   - '[[ "$VERSION" != "3.4" ]] || php framework-tests/bin/console doctrine:schema:update --force -n'
   - php ./vendor/bin/codecept build -c $TEST_PATH
 script:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": ">=5.6.0 <8.0",
+        "php": ">=7.0.8 <8.0",
         "codeception/lib-innerbrowser": "^1.3",
         "codeception/codeception": "^4.0"
     },

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 A Codeception module for Symfony framework.
 
+[![Actions Status](https://github.com/Codeception/module-symfony/workflows/CI/badge.svg)](https://github.com/Codeception/module-symfony/actions)
 [![Build Status](https://travis-ci.org/Codeception/module-symfony.svg?branch=master)](https://travis-ci.org/Codeception/module-symfony)
 
 ## Installation

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -29,7 +29,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
  *
  * ## Config
  *
- * ### Symfony 4.x
+ * ### Symfony 5.x or 4.x
  *
  * * app_path: 'src' - in Symfony 4 Kernel is located inside `src`
  * * environment: 'local' - environment used for load kernel
@@ -70,26 +70,6 @@ use Symfony\Component\VarDumper\Cloner\Data;
  *               var_path: 'var'
  *               environment: 'local_test'
  *
- *
- * ### Symfony 2.x
- *
- * * app_path: 'app' - specify custom path to your app dir, where bootstrap cache and kernel interface is located.
- * * environment: 'local' - environment used for load kernel
- * * kernel_class: 'AppKernel' - kernel class name
- * * debug: true - turn on/off debug mode
- * * em_service: 'doctrine.orm.entity_manager' - use the stated EntityManager to pair with Doctrine Module.
- * * cache_router: 'false' - enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
- * * rebootable_client: 'true' - reboot client's kernel before each request
- * * mailer: 'swiftmailer' - choose the mailer used by your application
- *
- * ### Example (`functional.suite.yml`) - Symfony 2.x Directory Structure
- *
- * ```
- *    modules:
- *        - Symfony:
- *            app_path: 'app/front'
- *            environment: 'local_test'
- * ```
  *
  * ## Public Properties
  *
@@ -250,7 +230,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     public function _getEntityManager()
     {
         if ($this->kernel === null) {
-            $this->fail('Symfony2 platform module is not loaded');
+            $this->fail('Symfony module is not loaded');
         }
         if (!isset($this->permanentServices[$this->config['em_service']])) {
             // try to persist configured EM


### PR DESCRIPTION
These versions have not been supported for a long time, it does not make sense to run tests on them in this module, or limit development for compatibility with these versions without security support.

So... with this PR:
- [x] I remove support for PHP version 5.6
- [x] I remove the tests from CI jobs for Symfony 2.8
- [x] I add PHP 7.4 to CI jobs.
- [x] I remove the references to Symfony 2.8 in the module.

