### PR TITLE
Update code standards to PHP 7.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": ">=7.0.8 <8.0",
         "codeception/lib-innerbrowser": "^1.3",
-        "codeception/codeception": "^4.0"
+        "codeception/codeception": "^4.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "codeception/module-asserts": "^1.3",

--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib\Connector;
 
 use InvalidArgumentException;
@@ -42,11 +44,11 @@ class Symfony extends HttpKernelBrowser
      * @param array             $services   An injected services
      * @param bool              $rebootable
      */
-    public function __construct(Kernel $kernel, array $services = [], $rebootable = true)
+    public function __construct(Kernel $kernel, array $services = [], bool $rebootable = true)
     {
         parent::__construct($kernel);
         $this->followRedirects(true);
-        $this->rebootable = (boolean)$rebootable;
+        $this->rebootable = $rebootable;
         $this->persistentServices = $services;
         $this->container = $this->kernel->getContainer();
         $this->rebootKernel();
@@ -56,7 +58,7 @@ class Symfony extends HttpKernelBrowser
      * @param Request $request
      * @return Response
      */
-    protected function doRequest($request)
+    protected function doRequest($request): Response
     {
         if ($this->rebootable) {
             if ($this->hasPerformedRequest) {
@@ -78,7 +80,7 @@ class Symfony extends HttpKernelBrowser
     public function rebootKernel()
     {
         if ($this->container) {
-            foreach ($this->persistentServices as $serviceName => $service) {
+            foreach (array_keys($this->persistentServices) as $serviceName) {
                 if ($this->container->has($serviceName)) {
                     $this->persistentServices[$serviceName] = $this->container->get($serviceName);
                 }
@@ -87,6 +89,7 @@ class Symfony extends HttpKernelBrowser
 
         $this->kernel->shutdown();
         $this->kernel->boot();
+
         $this->container = $this->kernel->getContainer();
 
         foreach ($this->persistentServices as $serviceName => $service) {


### PR DESCRIPTION
**composer.json**
* Added `"ext-json": "*"` because `json_encode` is used in `seeNumRecords`.

**src/Codeception/Lib/Connector/Symfony.php**
* Added strict types:  `declare(strict_types=1);`
* `array_keys` was used in `rebootKernel`'s foreach because it was only necessary to know the keys in that loop.

**src/Codeception/Module/Symfony.php**

* Added strict types:  `declare(strict_types=1);`
* `array_keys` was used in `_after`'s foreach because it was only necessary to know the keys in that loop.
* Imported classes with the `use` statement whenever possible
* `self::class` instead of `__CLASS__`.
* Added types to the arguments whenever possible, and explicit type cast when it was necessary.
* Used PHP if/else shorthand in `seeAuthentication` and `dontSeeAuthentication`.