### PR TITLE
Added grabCollector function

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -21,6 +21,7 @@ use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -663,6 +664,34 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             $this->fail($e->getMessage());
         }
         return null;
+    }
+
+    /**
+     * Grabs a Symfony Data Collector
+     *
+     * @param string $collector
+     * @param string $function
+     * @param string|null $message
+     * @return DataCollectorInterface
+     */
+    protected function grabCollector(string $collector, string $function, $message = null): DataCollectorInterface
+    {
+        if (!$profile = $this->getProfile()) {
+            $this->fail(
+                sprintf("The Profile is needed to use the '%s' function.", $function)
+            );
+        }
+
+        if (!$profile->hasCollector($collector)) {
+            if ($message) {
+                $this->fail($message);
+            }
+            $this->fail(
+                sprintf("The '%s' collector is needed to use the '%s' function.", $collector, $function)
+            );
+        }
+
+        return $profile->getCollector($collector);
     }
 
     /**


### PR DESCRIPTION
**TL:DR**: I have ready PRs that will make use of this function. It is for internal use only. Some functions are present in the Laravel module and need symfony collectors. This will avoid repeating validation code like in #44.

<details>
<summary>Clic to see full description</summary>

<br/>
I'm writing at least 4 functions related to form errors that are already available in the Laravel module:
- seeFormHasErrors()
- dontSeeFormErrors()
- seeFormErrorMessages()
- seeFormErrorMessage()

And others totally new functions like:
- dontSeeMissingTranslations();
- seeEventWasTriggered();
- dontSeeDeprecations();

Since all these functions will need their respective collectors of the Symfony Profiler, it is necessary to have a function that validates that it exists and fails the test otherwise,

With `grabCollector` i avoid repeating code and having to optimize it later as in #44 .
This function is intended only for internal use. with `protected` access to be consistent with the other methods of the module.

I'll start sending the PRs of the functions I mentioned as soon as this gets merged to master, since the tests will fail before then.
</details>
