### PR TITLE
Added seeFormHasErrors function

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -1171,6 +1171,27 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
+     * Verifies that there are one or more errors bound to the submitted form.
+     *
+     * ``` php
+     * <?php
+     * $I->seeFormHasErrors();
+     * ```
+     *
+     * @return void
+     */
+    public function seeFormHasErrors()
+    {
+        $formCollector = $this->grabCollector('form', __FUNCTION__);
+
+        $this->assertGreaterThan(
+            0,
+            $formCollector->getData()->offsetGet('nb_errors'),
+            'Expecting that the form has errors, but there were none!'
+        );
+    }
+
+    /**
      * Grab a Doctrine entity repository.
      * Works with objects, entities, repositories, and repository interfaces.
      *


### PR DESCRIPTION
It is [also present](https://github.com/Codeception/module-laravel5/blob/1d8a82f78a6e8c26f49af65d9001fa311785d54b/src/Codeception/Module/Laravel5.php#L661) in the Laravel Module,

Check for errors after submitting a form.

