### PR TITLE
Test the module in symfony 3.4 and php7.3+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,6 @@ jobs:
         php: [7.0, 7.1, 7.2, 7.3, 7.4]
         symfony: [3.4, 4, 5]
         exclude:
-          - php: 7.3
-            symfony: 3.4
-          - php: 7.4
-            symfony: 3.4
           - php: 7.0
             symfony: 4
           - php: 7.0


### PR DESCRIPTION
This module is currently not being tested in Symfony 3.4 on PHP 7.3 and PHP 7.4 (and soon neither on php8) due to a error (you can check it in the CI Build).

Apparently this error originates from the test project code.