### PR TITLE
Adding `dontSeeInSession()`

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -935,7 +935,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
         if (null === $value) {
             if ($session->has($attribute)) {
-                $this->fail("No session attribute with name '$attribute'");
+                $this->fail("Session attribute with name '$attribute' does exist");
             }
         }
         else {

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -917,6 +917,26 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
+     * Assert that a session attribute does not exist.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeInSession('attribute');
+     * ```
+     *
+     * @param string $attribute
+     * @return void
+     */
+    public function dontSeeInSession(string $attribute)
+    {
+        $session = $this->grabService('session');
+
+        if ($session->has($attribute)) {
+            $this->fail("Session attribute with name '$attribute' does exist");
+        }
+    }
+
+    /**
      * Opens web page by action name
      *
      * ``` php

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -917,22 +917,29 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
-     * Assert that a session attribute does not exist.
+     * Assert that a session attribute does not exist, or is not equal to the passed value.
      *
      * ```php
      * <?php
      * $I->dontSeeInSession('attribute');
+     * $I->dontSeeInSession('attribute', 'value');
      * ```
      *
      * @param string $attribute
+     * @param mixed|null $value
      * @return void
      */
-    public function dontSeeInSession(string $attribute)
+    public function dontSeeInSession(string $attribute, $value = null)
     {
         $session = $this->grabService('session');
 
-        if ($session->has($attribute)) {
-            $this->fail("Session attribute with name '$attribute' does exist");
+        if (null === $value) {
+            if ($session->has($attribute)) {
+                $this->fail("No session attribute with name '$attribute'");
+            }
+        }
+        else {
+            $this->assertNotEquals($value, $session->get($attribute));
         }
     }
 


### PR DESCRIPTION
`seeInSession()` was already there, but the opposite was missing.

I omitted the `$value` parameter for this reason: If `$attribute` is *not* in the session, it doesn't make much sense to do an additional check about its (inexistent) value. Or does it?

Tests are missing, but I don't know how to do that :-(