### PR TITLE
Remove PHP 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": ">=7.0.8 <9.0",
+        "php": ">=7.1.3 <9.0",
         "codeception/lib-innerbrowser": "^1.3",
         "codeception/codeception": "^4.0",
         "ext-json": "*"


### PR DESCRIPTION
In accordance with what is mentioned in (#39) this module proceeds to progressively remove support for obsolete versions of PHP.

This time 7.0, which has not had any kind of support for 2 years.