### PR TITLE
Remove param flags from authentication methods

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -1030,6 +1030,27 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
+     * Checks that a user is authenticated with the 'remember me' option.
+     *
+     * ```php
+     * <?php
+     * $I->seeRememberedAuthentication();
+     * ```
+     */
+    public function seeRememberedAuthentication()
+    {
+        $security = $this->grabService('security.helper');
+
+        $user = $security->getUser();
+
+        if (!$user) {
+            $this->fail('There is no user in session');
+        }
+
+        $this->assertTrue($security->isGranted('IS_AUTHENTICATED_REMEMBERED'), 'There is no authenticated user');
+    }
+
+    /**
      * Check that the current user has a role
      *
      * ```php

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -1051,6 +1051,24 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
+     * Check that user is not authenticated with the 'remember me' option.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeRememberedAuthentication();
+     * ```
+     */
+    public function dontSeeRememberedAuthentication()
+    {
+        $security = $this->grabService('security.helper');
+
+        $this->assertFalse(
+            $security->isGranted('IS_AUTHENTICATED_REMEMBERED'),
+            'There is an user authenticated'
+        );
+    }
+
+    /**
      * Check that the current user has a role
      *
      * ```php

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -979,17 +979,13 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
     /**
      * Checks that a user is authenticated.
-     * You can check users logged in with the option 'remember me' passing true as parameter.
      *
      * ```php
      * <?php
      * $I->seeAuthentication();
-     * $I->seeAuthentication(true);
      * ```
-     *
-     * @param bool $remembered
      */
-    public function seeAuthentication(bool $remembered = false)
+    public function seeAuthentication()
     {
         $security = $this->grabService('security.helper');
 
@@ -999,9 +995,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             $this->fail('There is no user in session');
         }
 
-        $role = $remembered ? 'IS_AUTHENTICATED_REMEMBERED' : 'IS_AUTHENTICATED_FULLY';
-
-        $this->assertTrue($security->isGranted($role), 'There is no authenticated user');
+        $this->assertTrue($security->isGranted('IS_AUTHENTICATED_FULLY'), 'There is no authenticated user');
     }
 
     /**
@@ -1067,23 +1061,18 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
     /**
      * Check that user is not authenticated.
-     * You can specify whether users logged in with the 'remember me' option should be ignored by passing 'false' as a parameter.
      *
      * ```php
      * <?php
      * $I->dontSeeAuthentication();
      * ```
-     *
-     * @param bool $remembered
      */
-    public function dontSeeAuthentication(bool $remembered = true)
+    public function dontSeeAuthentication()
     {
         $security = $this->grabService('security.helper');
 
-        $role = $remembered ? 'IS_AUTHENTICATED_REMEMBERED' : 'IS_AUTHENTICATED_FULLY';
-
         $this->assertFalse(
-            $security->isGranted($role),
+            $security->isGranted('IS_AUTHENTICATED_FULLY'),
             'There is an user authenticated'
         );
     }


### PR DESCRIPTION
With this PR the parameter flags of the authentication methods are removed (`$remembered` in this case), in addition, the following functions are added:

```php
public function seeRememberedAuthentication()
public function dontSeeRememberedAuthentication()
```

In order to supplement the previous functionality.

It's only a **BC** if you used `seeAuthentication` or `dontSeeAuthentication` with `true` as an argument.