### PR TITLE
Remove support for PHP 7.1 and PHP 7.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0]
         symfony: [3.4, 4.4, 5]
-        exclude:
-          - php: 7.1
-            symfony: 5
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": ">=7.1.3 <9.0",
+        "php": "^7.3 | ^8.0",
+        "ext-json": "*",
         "codeception/lib-innerbrowser": "^1.3",
-        "codeception/codeception": "^4.0",
-        "ext-json": "*"
+        "codeception/codeception": "^4.0"
     },
     "require-dev": {
         "codeception/module-asserts": "^1.3",

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,11 @@ A Codeception module for Symfony framework.
 
 [![Actions Status](https://github.com/Codeception/module-symfony/workflows/CI/badge.svg)](https://github.com/Codeception/module-symfony/actions)
 
+## Requirements
+
+* `Symfony 3.4` or higher.
+* `PHP 7.3` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -213,7 +213,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     protected $persistentServices = [];
 
-    public function _initialize()
+    public function _initialize(): void
     {
         $this->initializeSymfonyCache();
         $this->kernelClass = $this->getKernelClass();
@@ -234,7 +234,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     /**
      * Require Symfony's bootstrap.php.cache
      */
-    private function initializeSymfonyCache()
+    private function initializeSymfonyCache(): void
     {
         $cache = Configuration::projectDir() . $this->config['var_path'] . DIRECTORY_SEPARATOR . 'bootstrap.php.cache';
 
@@ -248,7 +248,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      *
      * @param TestInterface $test
      */
-    public function _before(TestInterface $test)
+    public function _before(TestInterface $test): void
     {
         $this->persistentServices = array_merge($this->persistentServices, $this->permanentServices);
         $this->client = new SymfonyConnector($this->kernel, $this->persistentServices, $this->config['rebootable_client']);
@@ -259,7 +259,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      *
      * @param TestInterface $test
      */
-    public function _after(TestInterface $test)
+    public function _after(TestInterface $test): void
     {
         foreach (array_keys($this->permanentServices) as $serviceName) {
             $this->permanentServices[$serviceName] = $this->grabService($serviceName);
@@ -267,7 +267,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         parent::_after($test);
     }
 
-    protected function onReconfigure($settings = [])
+    protected function onReconfigure($settings = []): void
     {
 
         parent::_beforeSuite($settings);
@@ -306,7 +306,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      *
      * @return ContainerInterface|mixed
      */
-    public function _getContainer()
+    public function _getContainer(): ContainerInterface
     {
         $container = $this->kernel->getContainer();
 
@@ -336,18 +336,18 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             throw new ModuleRequireException(
                 self::class,
                 "Can't load Kernel from $path.\n"
-                . "Directory does not exists. Use `app_path` parameter to provide valid application path"
+                . 'Directory does not exists. Use `app_path` parameter to provide valid application path'
             );
         }
 
         $finder = new Finder();
         $finder->name('*Kernel.php')->depth('0')->in($path);
         $results = iterator_to_array($finder);
-        if (count($results) === 0) {
+        if ($results === []) {
             throw new ModuleRequireException(
                 self::class,
                 "File with Kernel class was not found at $path. "
-                . "Specify directory where file with Kernel class for your application is located with `app_path` parameter."
+                . 'Specify directory where file with Kernel class for your application is located with `app_path` parameter.'
             );
         }
 
@@ -375,7 +375,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         throw new ModuleRequireException(
             self::class,
             "Kernel class was not found in $file. "
-            . "Specify directory where file with Kernel class for your application is located with `app_path` parameter."
+            . 'Specify directory where file with Kernel class for your application is located with `app_path` parameter.'
         );
     }
 
@@ -388,7 +388,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     {
         $service = $this->grabService($serviceName);
         $this->persistentServices[$serviceName] = $service;
-        if ($this->client) {
+        if ($this->client instanceof SymfonyConnector) {
             $this->client->persistentServices[$serviceName] = $service;
         }
     }
@@ -404,7 +404,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $service = $this->grabService($serviceName);
         $this->persistentServices[$serviceName] = $service;
         $this->permanentServices[$serviceName] = $service;
-        if ($this->client) {
+        if ($this->client instanceof SymfonyConnector) {
             $this->client->persistentServices[$serviceName] = $service;
         }
     }
@@ -422,7 +422,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         if (isset($this->permanentServices[$serviceName])) {
             unset($this->permanentServices[$serviceName]);
         }
-        if ($this->client && isset($this->client->persistentServices[$serviceName])) {
+        if ($this->client instanceof SymfonyConnector && isset($this->client->persistentServices[$serviceName])) {
             unset($this->client->persistentServices[$serviceName]);
         }
     }
@@ -451,7 +451,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     {
         /** @var RouterInterface $router */
         $router = $this->grabService('router');
-        if (!$router->getRouteCollection()->get($routeName)) {
+        if ($router->getRouteCollection()->get($routeName) === null) {
             $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
         }
         $url = $router->generate($routeName, $params);
@@ -474,7 +474,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     {
         /** @var RouterInterface $router */
         $router = $this->grabService('router');
-        if (!$router->getRouteCollection()->get($routeName)) {
+        if ($router->getRouteCollection()->get($routeName) === null) {
             $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
         }
 
@@ -505,7 +505,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     {
         /** @var RouterInterface $router */
         $router = $this->grabService('router');
-        if (!$router->getRouteCollection()->get($routeName)) {
+        if ($router->getRouteCollection()->get($routeName) === null) {
             $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
         }
 
@@ -828,7 +828,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     public function rebootClientKernel(): void
     {
-        if ($this->client) {
+        if ($this->client instanceof SymfonyConnector) {
             $this->client->rebootKernel();
         }
     }
@@ -1070,7 +1070,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
         $user = $security->getUser();
 
-        if (!$user) {
+        if ($user === null) {
             $this->fail('There is no user in session');
         }
 
@@ -1123,7 +1123,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
         $user = $security->getUser();
 
-        if (!$user) {
+        if ($user === null) {
             $this->fail('There is no user in session');
         }
 
@@ -1166,14 +1166,14 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
         $user = $security->getUser();
 
-        if (!$user) {
+        if ($user === null) {
             $this->fail('There is no user in session');
         }
 
         $this->assertTrue(
             $security->isGranted($role),
             sprintf(
-                "User %s has no role %s",
+                'User %s has no role %s',
                 $user->getUsername(),
                 $role
             )
@@ -1367,7 +1367,8 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         if ($user === null) {
             /** @var Security $security */
             $security = $this->grabService('security.helper');
-            if (!$user = $security->getUser()) {
+            $user = $security->getUser();
+            if ($user === null) {
                 $this->fail('No user found to validate');
             }
         }


### PR DESCRIPTION
This is the last PR that aims to put the supported PHP versions in sync with the versions required by this module.

[Rector](https://github.com/rectorphp/rector), [Psalm](https://github.com/vimeo/psalm), [Phpmd](https://github.com/phpmd/phpmd), [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) and [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) were executed to guarantee a consistent code.