### PR TITLE
Update seeEmailIsSent

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -69,7 +69,6 @@ use function is_string;
 use function is_subclass_of;
 use function iterator_to_array;
 use function json_encode;
-use function print_r;
 use function serialize;
 use function sprintf;
 use function strlen;
@@ -577,16 +576,15 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     public function seeEmailIsSent(?int $expectedCount = null): void
     {
-        if (($profile = $this->getProfile()) === null) {
-            $this->fail("Emails can't be tested without Profiler");
-        }
-
+        $realCount = 0;
         $mailer = $this->config['mailer'];
-        if ($mailer === self::SYMFONY_MAILER) {
-            $mailer = 'mailer';
-        }
-
-        if (!$profile->hasCollector($mailer)) {
+        if ($mailer === self::SWIFTMAILER) {
+            $mailCollector = $this->grabCollector('swiftmailer', __FUNCTION__);
+            $realCount = $mailCollector->getMessageCount();
+        } elseif ($mailer === self::SYMFONY_MAILER) {
+            $mailCollector = $this->grabCollector('mailer', __FUNCTION__);
+            $realCount = count($mailCollector->getEvents()->getMessages());
+        } else {
             $this->fail(
                 "Emails can't be tested without Mailer service connector.
                 Set your mailer service in `functional.suite.yml`: `mailer: swiftmailer`
@@ -594,24 +592,10 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             );
         }
 
-        if (!is_int($expectedCount) && !is_null($expectedCount)) {
-            $this->fail(sprintf(
-                'The required number of emails must be either an integer or null. "%s" was provided.',
-                print_r($expectedCount, true)
-            ));
-        }
-
-        $mailCollector = $profile->getCollector($mailer);
-        if ($mailer === self::SWIFTMAILER) {
-            $realCount = $mailCollector->getMessageCount();
-        } else {
-            $realCount = count($mailCollector->getEvents()->getMessages());
-        }
-
         if ($expectedCount !== null) {
             $this->assertEquals($expectedCount, $realCount, sprintf(
                 'Expected number of sent emails was %d, but in reality %d %s sent.',
-                $expectedCount, $realCount, $realCount === 2 ? 'was' : 'were'
+                $expectedCount, $realCount, $realCount === 1 ? 'was' : 'were'
             ));
             return;
         }


### PR DESCRIPTION
Now that `$expectedCount` is typed `?int`, it is no longer necessary:
```php
	if (!is_int($expectedCount) && !is_null($expectedCount)) { }
```
and if `grabCollector` is used, it is not necessary:
```php
	if (($profile = $this->getProfile()) === null) { }
	if (!$profile->hasCollector($mailer)) { }
```
since that method includes these validations.

> I remove an unused function declaration, and fix a conditional for the error message verb.