### PR TITLE
Add cookie validation to auth methods

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -1133,7 +1133,14 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             $this->fail('There is no user in session');
         }
 
-        $this->assertTrue($security->isGranted('IS_AUTHENTICATED_REMEMBERED'), 'There is no authenticated user');
+        $hasRememberMeCookie = $this->client->getCookieJar()->get('REMEMBERME');
+        $hasRememberMeRole = $security->isGranted('IS_AUTHENTICATED_REMEMBERED');
+
+        $isRemembered = $hasRememberMeCookie && $hasRememberMeRole;
+        $this->assertTrue(
+            $isRemembered,
+            'User does not have remembered authentication'
+        );
     }
 
     /**
@@ -1149,9 +1156,13 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         /** @var Security $security */
         $security = $this->grabService('security.helper');
 
+        $hasRememberMeCookie = $this->client->getCookieJar()->get('REMEMBERME');
+        $hasRememberMeRole = $security->isGranted('IS_AUTHENTICATED_REMEMBERED');
+
+        $isRemembered = $hasRememberMeCookie && $hasRememberMeRole;
         $this->assertFalse(
-            $security->isGranted('IS_AUTHENTICATED_REMEMBERED'),
-            'There is an user authenticated'
+            $isRemembered,
+            'User does have remembered authentication'
         );
     }
 

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -39,6 +39,7 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
@@ -1080,7 +1081,10 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             $this->fail('There is no user in session');
         }
 
-        $this->assertTrue($security->isGranted('IS_AUTHENTICATED_FULLY'), 'There is no authenticated user');
+        $this->assertTrue(
+            $security->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY),
+            'There is no authenticated user'
+        );
     }
 
     /**
@@ -1134,7 +1138,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         }
 
         $hasRememberMeCookie = $this->client->getCookieJar()->get('REMEMBERME');
-        $hasRememberMeRole = $security->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        $hasRememberMeRole = $security->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED);
 
         $isRemembered = $hasRememberMeCookie && $hasRememberMeRole;
         $this->assertTrue(
@@ -1157,7 +1161,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $security = $this->grabService('security.helper');
 
         $hasRememberMeCookie = $this->client->getCookieJar()->get('REMEMBERME');
-        $hasRememberMeRole = $security->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        $hasRememberMeRole = $security->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED);
 
         $isRemembered = $hasRememberMeCookie && $hasRememberMeRole;
         $this->assertFalse(
@@ -1211,7 +1215,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $security = $this->grabService('security.helper');
 
         $this->assertFalse(
-            $security->isGranted('IS_AUTHENTICATED_FULLY'),
+            $security->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY),
             'There is an user authenticated'
         );
     }


### PR DESCRIPTION
For remembered authentication methods `seeRememberedAuthentication` and `dontSeeRememberedAuthentication`, there are some cases in which it is necessary to verify not only the role but also the generated Cookie, that is why this logic is added to these methods.

Also, to add more clarity about the internals of these methods, the class constants of the Symfony Security component are used to make these assertions.

