### PR TITLE
Added info from the 'Codeception for Symfony' page

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -77,7 +77,14 @@ use function strpos;
 use function substr_compare;
 
 /**
- * This module uses Symfony Crawler and HttpKernel to emulate requests and test response.
+ * This module uses [Symfony's DomCrawler](https://symfony.com/doc/current/components/dom_crawler.html)
+ * and [HttpKernel Component](https://symfony.com/doc/current/components/http_kernel.html) to emulate requests and test response.
+ *
+ * * Access Symfony services through the dependency injection container: [`$I->grabService(...)`](#grabService)
+ * * Use Doctrine to test against the database: `$I->seeInRepository(...)` - see [Doctrine Module](https://codeception.com/docs/modules/Doctrine2)
+ * * Assert that emails would have been sent: [`$I->seeEmailIsSent()`](#seeEmailIsSent)
+ * * Tests are wrapped into Doctrine transaction to speed them up.
+ * * Symfony Router can be cached between requests to speed up testing.
  *
  * ## Demo Project
  *


### PR DESCRIPTION
I'd like to drop all those pages completely:
* https://codeception.com/for/symfony
* https://codeception.com/for/laravel
* etc.

I'm starting with Symfony (to show it's possible), and hopefully can motivate others to do the same for the other frameworks :-)

Reasons:
* Three pages explaining how to use Codeception with Symfony (each differently) are two too much :-) https://codeception.com/docs/modules/Symfony and https://codeception.com/for/symfony and https://codeception.com/09-04-2015/using-codeception-for-symfony-projects.html
  So the module page should be the only one, and it should contain everything.
* "use cases" is a misleading title for it; in fact it's just about frameworks ;-) WordPress and Joomla are exceptions - so if it's not possible to integrate them elsewhere, they can stay (renaming the button to "CMS")

So what I did is: I copied the "Features" list from https://codeception.com/for/symfony into the module page - and that's it! The rest of https://codeception.com/for/symfony has (a) nothing to do with Symfony (e.g. the shown configuration of "Acceptance Testing"), or (b) is explained elsewhere (e.g. BDD).

Questions:
* By "Symfony Crawler" you mean "DomCrawler"? (double-check the link I added)
* How does this work: "Symfony Router can be cached between requests to speed up testing"?
* I'm not 100% sure about the "API Tests" header, so please double-check if anything important from https://codeception.com/for/symfony#api-tests is missing at https://codeception.com/docs/10-APITesting#REST-API

So if you agree, I'll go ahead and delete https://github.com/Codeception/codeception.github.com/blob/master/for/symfony.md. If possible, the URL should be redirected to the module page.

BTW: What is https://github.com/Codeception/codeception.github.com/blob/master/for/zend-framework.md%7E ?