### PR TITLE
Update the `services` Part

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -114,7 +114,11 @@ use function sprintf;
  *
  * ## Parts
  *
- * * `services`: Symfony dependency injection container (DIC)
+ * * `services`: Includes methods related to the Symfony dependency injection container (DIC):
+ *     * grabService
+ *     * persistService
+ *     * persistPermanentService
+ *     * unpersistService
  *
  * See [WebDriver module](https://codeception.com/docs/modules/WebDriver#Loading-Parts-from-other-Modules)
  * for general information on how to load parts of a framework module.

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -10,8 +10,6 @@ trait MailerAssertionsTrait
 {
     /**
      * Checks that no email was sent. This is an alias for seeEmailIsSent(0).
-     *
-     * @part email
      */
     public function dontSeeEmailIsSent(): void
     {

--- a/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
@@ -18,9 +18,9 @@ trait ServicesAssertionsTrait
      * $em = $I->grabService('doctrine');
      * ```
      *
+     * @part services
      * @param string $service
      * @return mixed
-     * @part services
      */
     public function grabService(string $service)
     {
@@ -36,6 +36,7 @@ trait ServicesAssertionsTrait
     /**
      * Get service $serviceName and add it to the lists of persistent services.
      *
+     * @part services
      * @param string $serviceName
      */
     public function persistService(string $serviceName): void
@@ -51,6 +52,7 @@ trait ServicesAssertionsTrait
      * Get service $serviceName and add it to the lists of persistent services,
      * making that service persistent between tests.
      *
+     * @part services
      * @param string $serviceName
      */
     public function persistPermanentService(string $serviceName): void
@@ -66,6 +68,7 @@ trait ServicesAssertionsTrait
     /**
      * Remove service $serviceName from the lists of persistent services.
      *
+     * @part services
      * @param string $serviceName
      */
     public function unpersistService(string $serviceName): void


### PR DESCRIPTION
Just to be consistent, the `services` part is updated, which is the only one documented (and useful?).

The `email` part was never documented (or used?), so that excess annotation is removed as well.