### PR TITLE
Encapsulate services and collectors

### DIFF
--- a/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
@@ -6,6 +6,7 @@ namespace Codeception\Module\Symfony;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 trait ConsoleAssertionsTrait
 {
@@ -26,7 +27,7 @@ trait ConsoleAssertionsTrait
      */
     public function runSymfonyConsoleCommand(string $command, array $parameters = [], array $consoleInputs = [], int $expectedExitCode = 0): string
     {
-        $kernel = $this->grabService('kernel');
+        $kernel = $this->grabKernelService();
         $application = new Application($kernel);
         $consoleCommand = $application->find($command);
         $commandTester = new CommandTester($consoleCommand);
@@ -44,5 +45,10 @@ trait ConsoleAssertionsTrait
         );
 
         return $output;
+    }
+
+    protected function grabKernelService(): KernelInterface
+    {
+        return $this->grabService('kernel');
     }
 }

--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -27,8 +27,7 @@ trait EventsAssertionsTrait
      */
     public function dontSeeEventTriggered($expected): void
     {
-        /** @var EventDataCollector $eventCollector */
-        $eventCollector = $this->grabCollector('events', __FUNCTION__);
+        $eventCollector = $this->grabEventCollector(__FUNCTION__);
 
         /** @var Data $data */
         $data = $eventCollector->getNotCalledListeners();
@@ -63,8 +62,7 @@ trait EventsAssertionsTrait
      */
     public function seeEventTriggered($expected): void
     {
-        /** @var EventDataCollector $eventCollector */
-        $eventCollector = $this->grabCollector('events', __FUNCTION__);
+        $eventCollector = $this->grabEventCollector(__FUNCTION__);
 
         /** @var Data $data */
         $data = $eventCollector->getCalledListeners();
@@ -87,5 +85,10 @@ trait EventsAssertionsTrait
             }
             $this->assertTrue($triggered, "The '$expectedEvent' event did not trigger");
         }
+    }
+
+    protected function grabEventCollector(string $function): EventDataCollector
+    {
+        return $this->grabCollector('events', $function);
     }
 }

--- a/src/Codeception/Module/Symfony/FormAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/FormAssertionsTrait.php
@@ -22,8 +22,7 @@ trait FormAssertionsTrait
      */
     public function dontSeeFormErrors(): void
     {
-        /** @var FormDataCollector $formCollector */
-        $formCollector = $this->grabCollector('form', __FUNCTION__);
+        $formCollector = $this->grabFormCollector(__FUNCTION__);
 
         $this->assertEquals(
             0,
@@ -47,8 +46,7 @@ trait FormAssertionsTrait
      */
     public function seeFormErrorMessage(string $field, ?string $message = null): void
     {
-        /** @var FormDataCollector $formCollector */
-        $formCollector = $this->grabCollector('form', __FUNCTION__);
+        $formCollector = $this->grabFormCollector(__FUNCTION__);
 
         if (!$forms = $formCollector->getData()->getValue('forms')['forms']) {
             $this->fail('There are no forms on the current page.');
@@ -157,13 +155,17 @@ trait FormAssertionsTrait
      */
     public function seeFormHasErrors(): void
     {
-        /** @var FormDataCollector $formCollector */
-        $formCollector = $this->grabCollector('form', __FUNCTION__);
+        $formCollector = $this->grabFormCollector(__FUNCTION__);
 
         $this->assertGreaterThan(
             0,
             $formCollector->getData()->offsetGet('nb_errors'),
             'Expecting that the form has errors, but there were none!'
         );
+    }
+
+    protected function grabFormCollector(string $function): FormDataCollector
+    {
+        return $this->grabCollector('form', $function);
     }
 }

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -38,17 +38,13 @@ trait MailerAssertionsTrait
 
     protected function getMessageMailerEvents(): MessageEvents
     {
-        $container = $this->_getContainer();
-
-        if ($container->has('mailer.message_logger_listener')) {
+        if ($messageLogger = $this->getService('mailer.message_logger_listener')) {
             /** @var MessageLoggerListener $messageLogger */
-            $messageLogger = $container->get('mailer.message_logger_listener');
             return $messageLogger->getEvents();
         }
 
-        if ($container->has('mailer.logger_message_listener')) {
+        if ($messageLogger = $this->getService('mailer.logger_message_listener')) {
             /** @var MessageLoggerListener $messageLogger */
-            $messageLogger = $container->get('mailer.logger_message_listener');
             return $messageLogger->getEvents();
         }
 

--- a/src/Codeception/Module/Symfony/ParameterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ParameterAssertionsTrait.php
@@ -21,8 +21,12 @@ trait ParameterAssertionsTrait
      */
     public function grabParameter(string $name)
     {
-        /** @var ParameterBagInterface $parameterBag */
-        $parameterBag = $this->grabService('parameter_bag');
+        $parameterBag = $this->grabParameterBagService();
         return $parameterBag->get($name);
+    }
+
+    protected function grabParameterBagService(): ParameterBagInterface
+    {
+        return $this->grabService('parameter_bag');
     }
 }

--- a/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
@@ -32,8 +32,7 @@ trait RouterAssertionsTrait
      */
     public function amOnAction(string $action, array $params = []): void
     {
-        /** @var RouterInterface $router */
-        $router = $this->grabService('router');
+        $router = $this->grabRouterService();
 
         $routes = $router->getRouteCollection()->getIterator();
 
@@ -66,8 +65,7 @@ trait RouterAssertionsTrait
      */
     public function amOnRoute(string $routeName, array $params = []): void
     {
-        /** @var RouterInterface $router */
-        $router = $this->grabService('router');
+        $router = $this->grabRouterService();
         if ($router->getRouteCollection()->get($routeName) === null) {
             $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
         }
@@ -96,8 +94,7 @@ trait RouterAssertionsTrait
      */
     public function seeCurrentActionIs(string $action): void
     {
-        /** @var RouterInterface $router */
-        $router = $this->grabService('router');
+        $router = $this->grabRouterService();
 
         $routes = $router->getRouteCollection()->getIterator();
 
@@ -129,8 +126,7 @@ trait RouterAssertionsTrait
      */
     public function seeCurrentRouteIs(string $routeName, array $params = []): void
     {
-        /** @var RouterInterface $router */
-        $router = $this->grabService('router');
+        $router = $this->grabRouterService();
         if ($router->getRouteCollection()->get($routeName) === null) {
             $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
         }
@@ -160,8 +156,7 @@ trait RouterAssertionsTrait
      */
     public function seeInCurrentRoute(string $routeName): void
     {
-        /** @var RouterInterface $router */
-        $router = $this->grabService('router');
+        $router = $this->grabRouterService();
         if ($router->getRouteCollection()->get($routeName) === null) {
             $this->fail(sprintf('Route with name "%s" does not exists.', $routeName));
         }
@@ -174,5 +169,10 @@ trait RouterAssertionsTrait
         }
 
         $this->assertEquals($matchedRouteName, $routeName);
+    }
+
+    protected function grabRouterService(): RouterInterface
+    {
+        return $this->grabService('router');
     }
 }

--- a/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
@@ -19,18 +19,17 @@ trait ServicesAssertionsTrait
      * ```
      *
      * @part services
-     * @param string $service
-     * @return mixed
+     * @param string $serviceId
+     * @return object
      */
-    public function grabService(string $service)
+    public function grabService(string $serviceId): object
     {
-        $container = $this->_getContainer();
-        if (!$container->has($service)) {
-            $this->fail("Service $service is not available in container.
+        if (!$service = $this->getService($serviceId)) {
+            $this->fail("Service $serviceId is not available in container.
             If the service isn't injected anywhere in your app, you need to set it to `public` in your `config/services_test.php`/`.yaml`,
             see https://symfony.com/doc/current/testing.html#accessing-the-container");
         }
-        return $container->get($service);
+        return $service;
     }
 
     /**
@@ -82,5 +81,14 @@ trait ServicesAssertionsTrait
         if ($this->client instanceof SymfonyConnector && isset($this->client->persistentServices[$serviceName])) {
             unset($this->client->persistentServices[$serviceName]);
         }
+    }
+
+    protected function getService(string $serviceId): ?object
+    {
+        $container = $this->_getContainer();
+        if ($container->has($serviceId)) {
+            return $container->get($serviceId);
+        }
+        return null;
     }
 }

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -34,8 +34,7 @@ trait SessionAssertionsTrait
      */
     public function amLoggedInAs(UserInterface $user, string $firewallName = 'main', $firewallContext = null): void
     {
-        /** @var SessionInterface $session */
-        $session = $this->grabService('session');
+        $session = $this->grabSessionService();
 
         if ($this->config['guard']) {
             $token = new PostAuthenticationGuardToken($user, $firewallName, $user->getRoles());
@@ -69,8 +68,7 @@ trait SessionAssertionsTrait
      */
     public function dontSeeInSession(string $attribute, $value = null): void
     {
-        /** @var SessionInterface $session */
-        $session = $this->grabService('session');
+        $session = $this->grabSessionService();
 
         if (null === $value) {
             if ($session->has($attribute)) {
@@ -92,15 +90,11 @@ trait SessionAssertionsTrait
      */
     public function logout(): void
     {
-        $container = $this->_getContainer();
-        if ($container->has('security.token_storage')) {
-            /** @var TokenStorageInterface $tokenStorage */
-            $tokenStorage = $this->grabService('security.token_storage');
+        if ($tokenStorage = $this->getTokenStorage()) {
             $tokenStorage->setToken();
         }
 
-        /** @var SessionInterface $session */
-        $session = $this->grabService('session');
+        $session = $this->grabSessionService();
 
         $sessionName = $session->getName();
         $session->invalidate();
@@ -132,8 +126,7 @@ trait SessionAssertionsTrait
      */
     public function seeInSession(string $attribute, $value = null): void
     {
-        /** @var SessionInterface $session */
-        $session = $this->grabService('session');
+        $session = $this->grabSessionService();
 
         if (!$session->has($attribute)) {
             $this->fail("No session attribute with name '$attribute'");
@@ -164,5 +157,15 @@ trait SessionAssertionsTrait
                 $this->seeInSession($key, $value);
             }
         }
+    }
+
+    protected function getTokenStorage(): ?TokenStorageInterface
+    {
+        return $this->getService('security.token_storage');
+    }
+
+    protected function grabSessionService(): SessionInterface
+    {
+        return $this->grabService('session');
     }
 }


### PR DESCRIPTION
Using strings like `'security.helper'` to get services (or collectors) in multiple places was a bad practice.

So in this PR, these identifiers are encapsulated in their own function cohesive to the trait to which they belong.

If one of them changes in the future, only one line of code needs to be changed.