### PR TITLE
Remove Symfony 3.4 Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         php: [7.3, 7.4, 8.0]
-        symfony: [3.4, 4.4, 5.2]
+        symfony: [4.4, 5.2]
 
     steps:
       - name: Checkout code
@@ -22,14 +22,6 @@ jobs:
           tools: composer:v2
           extensions: ctype, iconv, intl, json, mbstring, pdo, pdo_sqlite
           coverage: none
-
-      - name: Checkout Symfony 3.4 Sample
-        if: matrix.symfony == 3.4
-        uses: actions/checkout@v2
-        with:
-          repository: Codeception/symfony-module-tests
-          path: framework-tests
-          ref: 3.4
 
       - name: Checkout Symfony 4.4 Sample
         if: matrix.symfony == 4.4

--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -11,12 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Symfony\Component\HttpKernel\Kernel;
 use function array_keys;
-use function class_alias;
 use function codecept_debug;
-
-if (Kernel::VERSION_ID < 40300) {
-    class_alias('Symfony\Component\HttpKernel\Client', 'Symfony\Component\HttpKernel\HttpKernelBrowser');
-}
 
 class Symfony extends HttpKernelBrowser
 {


### PR DESCRIPTION
With this PR:
- The new minimum supported version is Symfony 4.4.
- All logic and docs that reference Symfony 3.4 are removed.
- Now `_getContainer` returns the test container first if it exists.
- `getPossibleKernelClasses` and `initializeSymfonyCache` methods removed.
- Removed the `var_path` config parameter.