### PR TITLE
Add suggested packages to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,10 @@
         "codeception/module-rest": "^1.2",
         "vlucas/phpdotenv": "^4.2 | ^5.3"
     },
+    "suggest": {
+        "codeception/module-asserts": "Include traditional PHPUnit assertions in your tests",
+        "symfony/web-profiler-bundle": "Tool that gives information about the execution of requests"
+    },
     "autoload": {
         "classmap": ["src/"]
     },


### PR DESCRIPTION
This module needs the profiler to a large extent, and you will generally need the assertions module after using some `grab` method so both packages are added as suggested installations.