### PR TITLE
Use AssertSame instead of AssertEquals

### DIFF
--- a/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
@@ -37,7 +37,7 @@ trait ConsoleAssertionsTrait
         $exitCode = $commandTester->execute($parameters);
         $output = $commandTester->getDisplay();
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedExitCode,
             $exitCode,
             'Command did not exit with code '.$expectedExitCode

--- a/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
@@ -118,7 +118,7 @@ trait DoctrineAssertionsTrait
     {
         $currentNum = $this->grabNumRecords($className, $criteria);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedNum,
             $currentNum,
             sprintf(

--- a/src/Codeception/Module/Symfony/FormAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/FormAssertionsTrait.php
@@ -24,9 +24,11 @@ trait FormAssertionsTrait
     {
         $formCollector = $this->grabFormCollector(__FUNCTION__);
 
-        $this->assertEquals(
+        $errors = (int) $formCollector->getData()->offsetGet('nb_errors');
+
+        $this->assertSame(
             0,
-            $formCollector->getData()->offsetGet('nb_errors'),
+            $errors,
             'Expecting that the form does not have errors, but there were!'
         );
     }

--- a/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
@@ -140,7 +140,7 @@ trait RouterAssertionsTrait
         $expected = array_merge(['_route' => $routeName], $params);
         $intersection = array_intersect_assoc($expected, $match);
 
-        $this->assertEquals($expected, $intersection);
+        $this->assertSame($expected, $intersection);
     }
 
     /**
@@ -163,12 +163,12 @@ trait RouterAssertionsTrait
 
         $uri = explode('?', $this->grabFromCurrentUrl())[0];
         try {
-            $matchedRouteName = $router->match($uri)['_route'];
+            $matchedRouteName = (string) $router->match($uri)['_route'];
         } catch (ResourceNotFoundException $e) {
             $this->fail(sprintf('The "%s" url does not match with any route', $uri));
         }
 
-        $this->assertEquals($matchedRouteName, $routeName);
+        $this->assertSame($matchedRouteName, $routeName);
     }
 
     protected function grabRouterService(): RouterInterface

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -76,7 +76,7 @@ trait SessionAssertionsTrait
             }
         }
         else {
-            $this->assertNotEquals($value, $session->get($attribute));
+            $this->assertNotSame($value, $session->get($attribute));
         }
     }
 
@@ -133,7 +133,7 @@ trait SessionAssertionsTrait
         }
 
         if (null !== $value) {
-            $this->assertEquals($value, $session->get($attribute));
+            $this->assertSame($value, $session->get($attribute));
         }
     }
 

--- a/src/Codeception/Module/Symfony/TwigAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/TwigAssertionsTrait.php
@@ -47,9 +47,9 @@ trait TwigAssertionsTrait
         $twigCollector = $this->grabTwigCollector(__FUNCTION__);
 
         $templates = (array) $twigCollector->getTemplates();
-        $actualTemplate = array_key_first($templates);
+        $actualTemplate = (string) array_key_first($templates);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedTemplate,
             $actualTemplate,
             "Actual template {$actualTemplate} does not match expected template {$expectedTemplate}."


### PR DESCRIPTION
In the past, strict types were implemented, parameters were typed, and framework calls included explicit casts.

It is time to make use of this design in assertions as well.