### PR TITLE
Make url parameter optional in `seePageIsAvailable`

### DIFF
--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -34,20 +34,26 @@ trait BrowserAssertionsTrait
     }
 
     /**
-     * Goes to a page and check that it can be accessed.
+     * Verifies that a page is available.
+     * By default it checks the current page, specify the `$url` parameter to change it.
      *
      * ```php
      * <?php
-     * $I->seePageIsAvailable('/dashboard');
+     * $I->amOnPage('/dashboard');
+     * $I->seePageIsAvailable();
+     *
+     * $I->seePageIsAvailable('/dashboard'); // Same as above
      * ```
      *
-     * @param string $url
+     * @param string|null $url
      */
-    public function seePageIsAvailable(string $url): void
+    public function seePageIsAvailable(string $url = null): void
     {
-        $this->amOnPage($url);
+        if ($url !== null) {
+            $this->amOnPage($url);
+            $this->seeInCurrentUrl($url);
+        }
         $this->seeResponseCodeIsSuccessful();
-        $this->seeInCurrentUrl($url);
     }
 
     /**


### PR DESCRIPTION
I have been monitoring the use of this method in the public repositories that use this module. 

I'm glad to see that it quickly became a very popular assertion. This is mainly because it is more natural to talk about available pages than 2xx response codes.

However, I have seen that in many cases `amOnPage` is used as a previous step, perhaps because it is more natural to read them separately. To avoid redundancies, the `$url` parameter will be optional, so both ways (the current one with a parameter, and the new one, without it) will be valid no matter which one you choose to use.