### PR TITLE
Remove REST module as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "require-dev": {
         "codeception/module-asserts": "^1.3",
         "codeception/module-doctrine2": "^1.1",
-        "codeception/module-rest": "^1.2",
         "vlucas/phpdotenv": "^4.2 | ^5.3"
     },
     "suggest": {

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -23,7 +23,7 @@ trait MailerAssertionsTrait
      * Checks if the desired number of emails was sent.
      * Asserts that 1 email was sent by default, specify the `expectedCount` parameter to modify it.
      * The email is checked using Symfony message logger, which means:
-     * * If your app performs a redirect after sending the email, you need to suppress this using REST Module's [stopFollowingRedirects](https://codeception.com/docs/modules/REST#stopFollowingRedirects)
+     * * If your app performs a redirect after sending the email, you need to suppress it using [stopFollowingRedirects](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects).
      *
      * ```php
      * <?php


### PR DESCRIPTION
`Codeception/lib-innerbrowser` implemented redirection methods since [version 1.4.0](https://github.com/Codeception/lib-innerbrowser/releases/tag/1.4.0), therefore, the symfony module no longer needs to use the methods of the REST module to stop redirects when asserting about emails.

