### PR TITLE
Explaining the stopFollowingRedirects() restriction for email

### DIFF
--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -13,6 +13,8 @@ trait MailerAssertionsTrait
 {
     /**
      * Checks that no email was sent.
+     * The check is based on `\Symfony\Component\Mailer\EventListener\MessageLoggerListener`, which means:
+     * If your app performs a HTTP redirect, you need to suppress it using [stopFollowingRedirects()](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects) first; otherwise this check will *always* pass.
      */
     public function dontSeeEmailIsSent(): void
     {
@@ -38,6 +40,8 @@ trait MailerAssertionsTrait
 
     /**
      * Returns the last sent email.
+     * The function is based on `\Symfony\Component\Mailer\EventListener\MessageLoggerListener`, which means:
+     * If your app performs a HTTP redirect after sending the email, you need to suppress it using [stopFollowingRedirects()](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects) first.
      *
      * ```php
      * <?php
@@ -60,6 +64,8 @@ trait MailerAssertionsTrait
 
     /**
      * Returns an array of all sent emails.
+     * The function is based on `\Symfony\Component\Mailer\EventListener\MessageLoggerListener`, which means:
+     * If your app performs a HTTP redirect after sending the email, you need to suppress it using [stopFollowingRedirects()](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects) first.
      *
      * ```php
      * <?php

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -20,10 +20,9 @@ trait MailerAssertionsTrait
     }
 
     /**
-     * Checks if the desired number of emails was sent.
-     * Asserts that 1 email was sent by default, specify the `expectedCount` parameter to modify it.
-     * The email is checked using Symfony message logger, which means:
-     * * If your app performs a redirect after sending the email, you need to suppress it using [stopFollowingRedirects](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects).
+     * Checks if the given number of emails was sent (default `$expectedCount`: 1).
+     * The check is based on `\Symfony\Component\Mailer\EventListener\MessageLoggerListener`, which means:
+     * If your app performs a HTTP redirect after sending the email, you need to suppress it using [stopFollowingRedirects()](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects) first.
      *
      * ```php
      * <?php


### PR DESCRIPTION
See https://github.com/Codeception/module-symfony/pull/107#issuecomment-799069222

This sentence is meant to be copied to all email-related functions:
* seeEmailIsSent
* dontSeeEmailIsSent
* grabSentEmails
* grabLastSentEmail