### PR TITLE
Adding @var annotation for return type

### DIFF
--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -42,9 +42,10 @@ trait MailerAssertionsTrait
      *
      * ```php
      * <?php
+     * /** @var ?\Symfony\Component\Mime\Email $email */
      * $email = $I->grabLastSentEmail();
      * $address = $email->getTo()[0];
-     * $I->assertSame('john_doe@user.com', $address->getAddress());
+     * $I->assertSame('john_doe@example.com', $address->getAddress());
      * ```
      *
      * @return \Symfony\Component\Mime\Email|null


### PR DESCRIPTION
... to better emphasize what you'll get back; especially since `@return \Symfony\Component\Mime\Email|null` isn't rendered right, due to https://github.com/Codeception/Codeception/issues/6104

So I added a docblock within the docblock, so to say ;-)