### PR TITLE
Added "See also"

### DIFF
--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -39,6 +39,7 @@ trait MailerAssertionsTrait
 
     /**
      * Returns the last sent email.
+     * See also: [grabSentEmails()](https://codeception.com/docs/modules/Symfony#grabSentEmails)
      *
      * ```php
      * <?php
@@ -61,12 +62,12 @@ trait MailerAssertionsTrait
 
     /**
      * Returns an array of all sent emails.
+     * See also: [grabLastSentEmail()](https://codeception.com/docs/modules/Symfony#grabLastSentEmail).
      *
      * ```php
      * <?php
+     * /** @var array<int, \Symfony\Component\Mime\Email> $emails */
      * $emails = $I->grabSentEmails();
-     * $address = $emails[0]->getTo()[0];
-     * $I->assertSame('john_doe@user.com', $address->getAddress());
      * ```
      *
      * @return \Symfony\Component\Mime\Email[]

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -66,7 +66,7 @@ trait MailerAssertionsTrait
      *
      * ```php
      * <?php
-     * /** @var array<int, \Symfony\Component\Mime\Email> $emails */
+     * /** @var array<int, \Symfony\Component\Mime\Email> $emails {@*}
      * $emails = $I->grabSentEmails();
      * ```
      *


### PR DESCRIPTION
I shortened the example, cause `$emails[0]->getTo()[0];` looks strange ;-) Instead, I added the "See also"-links which (I think) are a good idea in general since the page gets longer and longer, so it's harder to get an overview what functions do exist at all...

The `@var` annotation syntax is taken from https://phpstan.org/writing-php-code/phpdoc-types#general-arrays - I'm not 100% sure if this is the right way.

The closing `*/` in my new `@var` line now breaks the code completely ;-) (same as in https://github.com/Codeception/module-symfony/pull/119) - is there a way to escape this?