### PR TITLE
Standardize "@example.com" as domain in documentation

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -110,7 +110,7 @@ use function sprintf;
  *         - Doctrine2:
  *             depends: Symfony
  *         - WebDriver:
- *             url: http://your-url.com
+ *             url: http://example.com
  *             browser: firefox
  * ```
  *

--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -89,7 +89,7 @@ trait BrowserAssertionsTrait
      * ```php
      * <?php
      * $I->submitSymfonyForm('login_form', [
-     *     '[email]'    => 'john_doe@gmail.com',
+     *     '[email]'    => 'john_doe@example.com',
      *     '[password]' => 'secretForest'
      * ]);
      * ```

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -48,7 +48,7 @@ trait MailerAssertionsTrait
      * <?php
      * $email = $I->grabLastSentEmail();
      * $address = $email->getTo()[0];
-     * $I->assertSame('john_doe@user.com', $address->getAddress());
+     * $I->assertSame('john_doe@example.com', $address->getAddress());
      * ```
      *
      * @return \Symfony\Component\Mime\Email|null
@@ -72,8 +72,6 @@ trait MailerAssertionsTrait
      * ```php
      * <?php
      * $emails = $I->grabSentEmails();
-     * $address = $emails[0]->getTo()[0];
-     * $I->assertSame('john_doe@user.com', $address->getAddress());
      * ```
      *
      * @return \Symfony\Component\Mime\Email[]

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -23,7 +23,7 @@ trait SessionAssertionsTrait
      * ```php
      * <?php
      * $user = $I->grabEntityFromRepository(User::class, [
-     *     'email' => 'john_doe@gmail.com'
+     *     'email' => 'john_doe@example.com'
      * ]);
      * $I->amLoggedInAs($user);
      * ```


### PR DESCRIPTION
`example.com` is the "official" domain for such things: http://example.com/

For the removal, see https://github.com/Codeception/module-symfony/pull/120#issue-593067918