### PR TITLE
Mentioning Symfony Mailer requirement in v2.0.0

### DIFF
--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -15,6 +15,7 @@ trait MailerAssertionsTrait
      * Checks that no email was sent.
      * The check is based on `\Symfony\Component\Mailer\EventListener\MessageLoggerListener`, which means:
      * If your app performs a HTTP redirect, you need to suppress it using [stopFollowingRedirects()](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects) first; otherwise this check will *always* pass.
+     * Starting with version 2.0.0, `codeception/module-symfony` requires your app to use [Symfony Mailer](https://symfony.com/doc/current/mailer.html). If your app still uses [Swift Mailer](https://symfony.com/doc/current/email.html), set your version constraint to `^1.6`.
      */
     public function dontSeeEmailIsSent(): void
     {
@@ -43,6 +44,7 @@ trait MailerAssertionsTrait
      * Returns the last sent email.
      * The function is based on `\Symfony\Component\Mailer\EventListener\MessageLoggerListener`, which means:
      * If your app performs a HTTP redirect after sending the email, you need to suppress it using [stopFollowingRedirects()](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects) first.
+     * Starting with version 2.0.0, `codeception/module-symfony` requires your app to use [Symfony Mailer](https://symfony.com/doc/current/mailer.html). If your app still uses [Swift Mailer](https://symfony.com/doc/current/email.html), set your version constraint to `^1.6`.
      * See also: [grabSentEmails()](https://codeception.com/docs/modules/Symfony#grabSentEmails)
      *
      * ```php
@@ -68,6 +70,7 @@ trait MailerAssertionsTrait
      * Returns an array of all sent emails.
      * The function is based on `\Symfony\Component\Mailer\EventListener\MessageLoggerListener`, which means:
      * If your app performs a HTTP redirect after sending the email, you need to suppress it using [stopFollowingRedirects()](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects) first.
+     * Starting with version 2.0.0, `codeception/module-symfony` requires your app to use [Symfony Mailer](https://symfony.com/doc/current/mailer.html). If your app still uses [Swift Mailer](https://symfony.com/doc/current/email.html), set your version constraint to `^1.6`.
      * See also: [grabLastSentEmail()](https://codeception.com/docs/modules/Symfony#grabLastSentEmail)
      *
      * ```php

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -25,6 +25,7 @@ trait MailerAssertionsTrait
      * Checks if the given number of emails was sent (default `$expectedCount`: 1).
      * The check is based on `\Symfony\Component\Mailer\EventListener\MessageLoggerListener`, which means:
      * If your app performs a HTTP redirect after sending the email, you need to suppress it using [stopFollowingRedirects()](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects) first.
+     * Starting with version 2.0.0, `codeception/module-symfony` requires your app to use [Symfony Mailer](https://symfony.com/doc/current/mailer.html). If your app still uses [Swift Mailer](https://symfony.com/doc/current/email.html), set your version constraint to `^1.6`.
      *
      * ```php
      * <?php


### PR DESCRIPTION
Follow-up of https://github.com/Codeception/module-symfony/issues/125. My plan would be to copy this line to all email-related functions. Questions:
1. Is `^1.6` right?
2. The `mailer` configuration was never documented anywhere. But in v1.6, Swift Mailer is the default anyway, right? So this configuration is only relevant for people who still have v1.6 but use Symfony Mailer? And in this case, the better advice is to upgrade to v2, rather than configuring `mailer`?