### PR TITLE
submitSymfonyForm(): Mentioning `name` attribute

### DIFF
--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -83,7 +83,7 @@ trait BrowserAssertionsTrait
     /**
      * Submit a form specifying the form name only once.
      *
-     * Use this function instead of `$I->submitForm()` to avoid repeating the form name in the field selectors.
+     * Use this function instead of [`$I->submitForm()`](#submitForm) to avoid repeating the form name in the field selectors.
      * If you customized the names of the field selectors use `$I->submitForm()` for full control.
      *
      * ```php

--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -103,7 +103,7 @@ trait BrowserAssertionsTrait
 
         $params = [];
         foreach ($fields as $key => $value) {
-            $fixedKey = sprintf('%s[%s]', $name, $key);
+            $fixedKey = sprintf('%s%s', $name, $key);
             $params[$fixedKey] = $value;
         }
         $button = sprintf('%s_submit', $name);

--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -83,8 +83,8 @@ trait BrowserAssertionsTrait
     /**
      * Submit a form specifying the form name only once.
      *
-     * Use this function instead of $I->submitForm() to avoid repeating the form name in the field selectors.
-     * If you customized the names of the field selectors use $I->submitForm() for full control.
+     * Use this function instead of `$I->submitForm()` to avoid repeating the form name in the field selectors.
+     * If you customized the names of the field selectors use `$I->submitForm()` for full control.
      *
      * ```php
      * <?php
@@ -94,7 +94,7 @@ trait BrowserAssertionsTrait
      * ]);
      * ```
      *
-     * @param string $name
+     * @param string $name The `name` attribute of the `<form>` (you cannot use an array as selector here)
      * @param string[] $fields
      */
     public function submitSymfonyForm(string $name, array $fields): void
@@ -103,7 +103,7 @@ trait BrowserAssertionsTrait
 
         $params = [];
         foreach ($fields as $key => $value) {
-            $fixedKey = sprintf('%s%s', $name, $key);
+            $fixedKey = sprintf('%s[%s]', $name, $key);
             $params[$fixedKey] = $value;
         }
         $button = sprintf('%s_submit', $name);


### PR DESCRIPTION
I'm not sure about this!
But I think the submitted fieldname now is `myFormaddress`, instead of `myForm[address]` - that's what I'm trying to fix.
I didn't take a look at the tests you mentioned in https://github.com/Codeception/module-symfony/issues/54

BTW: I was first looking for this method in `FormAssertionsTrait.php`, is there a reason why you put it into `BrowserAssertionsTrait.php`?