### PR TITLE
Fix Doctrine Connection service alias

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -253,8 +253,8 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             if ($container->has('doctrine.orm.default_entity_manager')) {
                 $this->persistPermanentService('doctrine.orm.default_entity_manager');
             }
-            if ($container->has('doctrine.dbal.backend_connection')) {
-                $this->persistPermanentService('doctrine.dbal.backend_connection');
+            if ($container->has('doctrine.dbal.default_connection')) {
+                $this->persistPermanentService('doctrine.dbal.default_connection');
             }
         }
         return $this->permanentServices[$emService];


### PR DESCRIPTION
Fix alias name for Doctrine Connection service. Now `\Doctrine\DBAL\Connection` retreived from `_getEntityManager()->getConnection()` and `grabService(\Doctrine\DBAL\Connection)` are different which is a bug.