### PR TITLE
Fix event name assertion

### DIFF
--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -154,8 +154,9 @@ trait EventsAssertionsTrait
 
         foreach ($actual as $actualEvent) {
             if (is_array($actualEvent)) { // Called Listeners
-                if (strpos($actualEvent['pretty'], $expectedEvent) === 0) {
+                if (strpos($actualEvent['event'], $expectedEvent) === 0) {
                     $triggered = true;
+                    break;
                 }
             } else { // Orphan Events
                 if ($actualEvent === $expectedEvent) {


### PR DESCRIPTION
`$actualEvent` array has the following structure (at least when use `seeEventTriggered`):
```
(
    [event] => member.settings.change
    [priority] => 0
    [pretty] => App\Welcome\WelcomeListener::onMemberSettingsChange
    [stub] => App\Welcome\WelcomeListener::onMemberSettingsChange(MemberSettingsChangeEvent $changeEvent)
)
```
So `pretty` key contains the listener and the `event` is the actual name that should be compared.

Used versions:
```
symfony/stopwatch                              v5.3.4 
symfony/web-profiler-bundle                    v5.3.8
symfony/framework-bundle                       v5.3.8
codeception/module-symfony                     2.0.5
```

p.s. Orphan Events don't go to this array but I don't have solution for that.