### PR TITLE
[Codecept5] Improved support for Codeception 5/PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
         "codeception/module-asserts": "^2.0 || *@dev",
         "codeception/module-doctrine2": "^2.0 || *@dev",
         "doctrine/orm": "^2.10",
-        "symfony/form": "^4.4 | ^5.0 | ^6.0",
-        "symfony/framework-bundle": "^4.4 | ^5.0 | ^6.0",
-        "symfony/http-kernel": "^4.4 | ^5.0 | ^6.0",
-        "symfony/mailer": "^4.4 | ^5.0 | ^6.0",
-        "symfony/routing": "^4.4 | ^5.0 | ^6.0",
-        "symfony/security-bundle": "^4.4 | ^5.0 | ^6.0",
-        "symfony/twig-bundle": "^4.4 | ^5.0 | ^6.0",
+        "symfony/form": "^4.4 || ^5.4 || ^6.0",
+        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
+        "symfony/mailer": "^4.4 || ^5.4 || ^6.0",
+        "symfony/routing": "^4.4 || ^5.4 || ^6.0",
+        "symfony/security-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/twig-bundle": "^4.4 || ^5.4 || ^6.0",
         "vlucas/phpdotenv": "^4.2 || ^5.3"
     },
     "suggest": {
@@ -47,6 +47,7 @@
         ]
     },
     "config": {
-        "classmap-authoritative": true
+        "classmap-authoritative": true,
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,12 @@
 {
     "name": "codeception/module-symfony",
     "description": "Codeception module for Symfony framework",
-    "keywords": ["codeception", "symfony"],
-    "homepage": "https://codeception.com/",
-    "type": "library",
     "license": "MIT",
+    "type": "library",
+    "keywords": [
+        "codeception",
+        "symfony"
+    ],
     "authors": [
         {
             "name": "Michael Bodnarchuk"
@@ -14,32 +16,35 @@
             "homepage": "https://medium.com/@ganieves"
         }
     ],
-    "minimum-stability": "dev",
+    "homepage": "https://codeception.com/",
     "require": {
-        "php": "^7.4 | ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
-        "codeception/lib-innerbrowser": "^2.0 | *@dev",
-        "codeception/codeception": "dev-5.0-interfaces as 5.0.x-dev"
+        "codeception/codeception": "dev-5.0-interfaces as 5.0.0",
+        "codeception/lib-innerbrowser": "dev-master"
     },
     "require-dev": {
-        "codeception/module-asserts": "^2.0 | *@dev",
-        "codeception/module-doctrine2": "^2.0 | *@dev",
+        "codeception/module-asserts": "^2.0 || *@dev",
+        "codeception/module-doctrine2": "^2.0 || *@dev",
         "doctrine/orm": "^2.10",
-        "symfony/form": "^4.4 | ^5.0",
-        "symfony/framework-bundle": "^4.4 | ^5.0",
-        "symfony/http-kernel": "^4.4 | ^5.0",
-        "symfony/mailer": "^4.4 | ^5.0",
-        "symfony/routing": "^4.4 | ^5.0",
-        "symfony/security-bundle": "^4.4 | ^5.0",
-        "symfony/twig-bundle": "^4.4 | ^5.0",
-        "vlucas/phpdotenv": "^4.2 | ^5.3"
+        "symfony/form": "^4.4 | ^5.0 | ^6.0",
+        "symfony/framework-bundle": "^4.4 | ^5.0 | ^6.0",
+        "symfony/http-kernel": "^4.4 | ^5.0 | ^6.0",
+        "symfony/mailer": "^4.4 | ^5.0 | ^6.0",
+        "symfony/routing": "^4.4 | ^5.0 | ^6.0",
+        "symfony/security-bundle": "^4.4 | ^5.0 | ^6.0",
+        "symfony/twig-bundle": "^4.4 | ^5.0 | ^6.0",
+        "vlucas/phpdotenv": "^4.2 || ^5.3"
     },
     "suggest": {
         "codeception/module-asserts": "Include traditional PHPUnit assertions in your tests",
         "symfony/web-profiler-bundle": "Tool that gives information about the execution of requests"
     },
+    "minimum-stability": "dev",
     "autoload": {
-        "classmap": ["src/"]
+        "classmap": [
+            "src/"
+        ]
     },
     "config": {
         "classmap-authoritative": true

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
         "symfony/mailer": "^4.4 || ^5.4 || ^6.0",
         "symfony/routing": "^4.4 || ^5.4 || ^6.0",
         "symfony/security-bundle": "^4.4 || ^5.4 || ^6.0",
-        "symfony/twig-bundle": "^4.4 || ^5.4 || ^6.0",
-        "vlucas/phpdotenv": "^4.2 || ^5.3"
+        "symfony/twig-bundle": "^4.4 || ^5.4 || ^6.0"
     },
     "suggest": {
         "codeception/module-asserts": "Include traditional PHPUnit assertions in your tests",

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ A Codeception module for Symfony framework.
 
 ## Requirements
 
-* `Symfony 4.4` or higher.
+* `Symfony` `4.4.x`, `5.4.x` or `6.x` or higher, as per the [Symfony supported versions](https://symfony.com/releases).
 * `PHP 8.0` or higher.
 
 ## Installation

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -152,6 +152,9 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     public ?AbstractBrowser $client = null;
 
+    /**
+     * @var array<string, mixed>
+     */
     public array $config = [
         'app_path' => 'app',
         'kernel_class' => 'App\Kernel',


### PR DESCRIPTION
I need to do the following:

- [x] Consolidate Symfony version requirements compared to Codeception 5 (e.g. supported PHP versions).
Symfony 4.4 and 5.4 are LTS versions so are [updated to support the latest PHP versions](https://symfony.com/doc/current/contributing/community/releases.html#php-compatibility).

- [ ] Fix `codeception/codeception` version requirement.
- [ ] Fix `codeception/lib-innerbrowser` version requirement.
- [ ] Add several basic smoke tests?
- [ ] Correct commit message to be consistent with repository.

Bonus points (for a separate PR maybe):
- [ ] PHPStan (using config from [`module-doctrine2`](https://github.com/Codeception/module-doctrine2/blob/master/phpstan.neon))