### PR TITLE
Update event assertions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,12 @@ jobs:
     strategy:
       matrix:
         php: [8.0, 8.1, 8.2]
-        symfony: ["4.4.*", "5.4.*", "6.0.*", "6.1.*"]
+        symfony: ["4.4.*", "5.4.*", "6.0.*", "6.1.*", "6.2.*"]
         exclude:
           - php: 8.0
             symfony: "6.1.*"
+          - php: 8.0
+            symfony: "6.2.*"
 
     steps:
       - name: Checkout code
@@ -57,6 +59,14 @@ jobs:
           repository: Codeception/symfony-module-tests
           path: framework-tests
           ref: "6.1"
+
+      - name: Checkout Symfony 6.2 Sample
+        if: "matrix.symfony == '6.2.*'"
+        uses: actions/checkout@v2
+        with:
+          repository: Codeception/symfony-module-tests
+          path: framework-tests
+          ref: "6.2"
 
       - name: Get composer cache directory
         id: composer-cache

--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -6,6 +6,7 @@ namespace Codeception\Module\Symfony;
 
 use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
 use Symfony\Component\VarDumper\Cloner\Data;
+
 use function is_array;
 use function is_object;
 
@@ -57,7 +58,10 @@ trait EventsAssertionsTrait
      */
     public function dontSeeEvent(array|object|string $expected): void
     {
-        trigger_error('dontSeeEventTriggered is deprecated, please use dontSeeEventListenerIsCalled instead', E_USER_DEPRECATED);
+        trigger_error(
+            'dontSeeEventTriggered is deprecated, please use dontSeeEventListenerIsCalled instead',
+            E_USER_DEPRECATED
+        );
         $this->dontSeeEventListenerIsCalled($expected);
     }
 
@@ -94,34 +98,11 @@ trait EventsAssertionsTrait
      * ```
      *
      * @param object|string|string[] $expected
-     * @deprecated Use `dontSeeEventListenerCalled` instead.
+     * @deprecated Use `dontSeeEventListenerIsCalled` instead.
      */
     public function dontSeeEventTriggered(array|object|string $expected): void
     {
-        $this->dontSeeEventListenerCalled($expected);
-    }
-
-    /**
-     * Verifies that one or more event listeners were not called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->dontSeeEventListenerCalled('App\MyEventSubscriber');
-     * $I->dontSeeEventListenerCalled(new App\Events\MyEventSubscriber());
-     * $I->dontSeeEventListenerCalled(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
-     * ```
-     *
-     * @param object|string|string[] $expected
-     */
-    public function dontSeeEventListenerCalled(array|object|string $expected): void
-    {
-        $eventCollector = $this->grabEventCollector(__FUNCTION__);
-
-        /** @var Data $data */
-        $data = $eventCollector->getCalledListeners();
-        $expected = is_array($expected) ? $expected : [$expected];
-
-        $this->assertListenerNotCalled($data, $expected);
+        $this->dontSeeEventListenerIsCalled($expected);
     }
 
     /**
@@ -165,7 +146,10 @@ trait EventsAssertionsTrait
      */
     public function seeEvent(array|object|string $expected): void
     {
-        trigger_error('seeEventTriggered is deprecated, please use seeEventListenerIsCalled instead', E_USER_DEPRECATED);
+        trigger_error(
+            'seeEventTriggered is deprecated, please use seeEventListenerIsCalled instead',
+            E_USER_DEPRECATED
+        );
         $this->seeEventListenerIsCalled($expected);
     }
 
@@ -202,34 +186,11 @@ trait EventsAssertionsTrait
      * ```
      *
      * @param object|string|string[] $expected
-     * @deprecated Use `seeEventListenerCalled` instead.
+     * @deprecated Use `seeEventListenerIsCalled` instead.
      */
     public function seeEventTriggered(array|object|string $expected): void
     {
-        $this->seeEventListenerCalled($expected);
-    }
-
-    /**
-     * Verifies that one or more event listeners were called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->seeEventListenerCalled('App\MyEventSubscriber');
-     * $I->seeEventListenerCalled(new App\Events\MyEventSubscriber());
-     * $I->seeEventListenerCalled(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
-     * ```
-     *
-     * @param object|string|string[] $expected
-     */
-    public function seeEventListenerCalled(array|object|string $expected): void
-    {
-        $eventCollector = $this->grabEventCollector(__FUNCTION__);
-
-        /** @var Data $data */
-        $data = $eventCollector->getCalledListeners();
-        $expected = is_array($expected) ? $expected : [$expected];
-
-        $this->assertListenerCalled($data, $expected);
+        $this->seeEventListenerIsCalled($expected);
     }
 
     protected function assertEventNotTriggered(Data $data, array $expected): void

--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -48,6 +48,28 @@ trait EventsAssertionsTrait
      *
      * ```php
      * <?php
+     * $I->dontSeeEventTriggered('App\MyEvent');
+     * $I->dontSeeEventTriggered(new App\Events\MyEvent());
+     * $I->dontSeeEventTriggered(['App\MyEvent', 'App\MyOtherEvent']);
+     * ```
+     *
+     * @param object|string|string[] $expected
+     * @deprecated Use `dontSeeEventListenerIsCalled` instead.
+     */
+    public function dontSeeEventTriggered(array|object|string $expected): void
+    {
+        trigger_error(
+            'dontSeeEventTriggered is deprecated, please use dontSeeEventListenerIsCalled instead',
+            E_USER_DEPRECATED
+        );
+        $this->dontSeeEventListenerIsCalled($expected);
+    }
+
+    /**
+     * Verifies that one or more event listeners were not called during the test.
+     *
+     * ```php
+     * <?php
      * $I->dontSeeEventListenerIsCalled('App\MyEventListener');
      * $I->dontSeeEventListenerIsCalled(new App\Events\MyEventListener());
      * $I->dontSeeEventListenerIsCalled(['App\MyEventListener', 'App\MyOtherEventListener']);
@@ -63,24 +85,6 @@ trait EventsAssertionsTrait
         $expected = is_array($expected) ? $expected : [$expected];
 
         $this->assertEventNotTriggered($data, $expected);
-    }
-
-    /**
-     * Verifies that one or more event listeners were not called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->dontSeeEventTriggered('App\MyEventListener');
-     * $I->dontSeeEventTriggered(new App\Events\MyEventListener());
-     * $I->dontSeeEventTriggered(['App\MyEventSubscriber', 'App\MyOtherEventListener']);
-     * ```
-     *
-     * @param object|string|string[] $expected
-     * @deprecated Use `dontSeeEventListenerIsCalled` instead.
-     */
-    public function dontSeeEventTriggered(array|object|string $expected): void
-    {
-        $this->dontSeeEventListenerIsCalled($expected);
     }
 
     /**
@@ -114,6 +118,28 @@ trait EventsAssertionsTrait
      *
      * ```php
      * <?php
+     * $I->seeEventTriggered('App\MyEvent');
+     * $I->seeEventTriggered(new App\Events\MyEvent());
+     * $I->seeEventTriggered(['App\MyEvent', 'App\MyOtherEvent']);
+     * ```
+     *
+     * @param object|string|string[] $expected
+     * @deprecated Use `seeEventListenerIsCalled` instead.
+     */
+    public function seeEventTriggered(array|object|string $expected): void
+    {
+        trigger_error(
+            'seeEventTriggered is deprecated, please use seeEventListenerIsCalled instead',
+            E_USER_DEPRECATED
+        );
+        $this->seeEventListenerIsCalled($expected);
+    }
+
+    /**
+     * Verifies that one or more event listeners were called during the test.
+     *
+     * ```php
+     * <?php
      * $I->seeEventListenerIsCalled('App\MyEventListener');
      * $I->seeEventListenerIsCalled(new App\Events\MyEventListener());
      * $I->seeEventListenerIsCalled(['App\MyEventListener', 'App\MyOtherEventListener']);
@@ -129,24 +155,6 @@ trait EventsAssertionsTrait
         $expected = is_array($expected) ? $expected : [$expected];
 
         $this->assertEventTriggered($data, $expected);
-    }
-
-    /**
-     * Verifies that one or more event listeners were called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->seeEventTriggered('App\MyEventListener');
-     * $I->seeEventTriggered(new App\Events\MyEventListener());
-     * $I->seeEventTriggered(['App\MyEventListener', 'App\MyOtherEventListener']);
-     * ```
-     *
-     * @param object|string|string[] $expected
-     * @deprecated Use `seeEventListenerIsCalled` instead.
-     */
-    public function seeEventTriggered(array|object|string $expected): void
-    {
-        $this->seeEventListenerIsCalled($expected);
     }
 
     protected function assertEventNotTriggered(Data $data, array $expected): void

--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -46,7 +46,7 @@ trait EventsAssertionsTrait
     }
 
     /**
-     * Verifies that one or more event listeners were not called during the test.
+     * Verifies that one or more events were not dispatched during the test.
      *
      * ```php
      * <?php
@@ -57,7 +57,7 @@ trait EventsAssertionsTrait
      *
      * @param object|string|string[] $expected
      */
-    public function dontSeeEventTriggered(array|object|string $expected): void
+    public function dontSeeEvent(array|object|string $expected): void
     {
         $eventCollector = $this->grabEventCollector(__FUNCTION__);
 
@@ -66,6 +66,47 @@ trait EventsAssertionsTrait
         $expected = is_array($expected) ? $expected : [$expected];
 
         $this->assertEventNotTriggered($data, $expected);
+    }
+
+    /**
+     * Verifies that one or more event listeners were not called during the test.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeEventTriggered('App\MyEventSubscriber');
+     * $I->dontSeeEventTriggered(new App\Events\MyEventSubscriber());
+     * $I->dontSeeEventTriggered(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
+     * ```
+     *
+     * @param object|string|string[] $expected
+     * @deprecated Use `dontSeeEventListenerCalled` instead.
+     */
+    public function dontSeeEventTriggered(array|object|string $expected): void
+    {
+        $this->dontSeeEventListenerCalled($expected);
+    }
+
+    /**
+     * Verifies that one or more event listeners were not called during the test.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeEventListenerCalled('App\MyEventSubscriber');
+     * $I->dontSeeEventListenerCalled(new App\Events\MyEventSubscriber());
+     * $I->dontSeeEventListenerCalled(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
+     * ```
+     *
+     * @param object|string|string[] $expected
+     */
+    public function dontSeeEventListenerCalled(array|object|string $expected): void
+    {
+        $eventCollector = $this->grabEventCollector(__FUNCTION__);
+
+        /** @var Data $data */
+        $data = $eventCollector->getCalledListeners();
+        $expected = is_array($expected) ? $expected : [$expected];
+
+        $this->assertListenerNotCalled($data, $expected);
     }
 
     /**
@@ -96,18 +137,18 @@ trait EventsAssertionsTrait
     }
 
     /**
-     * Verifies that one or more event listeners were called during the test.
+     * Verifies that one or more events were dispatched during the test.
      *
      * ```php
      * <?php
-     * $I->seeEventTriggered('App\MyEvent');
-     * $I->seeEventTriggered(new App\Events\MyEvent());
-     * $I->seeEventTriggered(['App\MyEvent', 'App\MyOtherEvent']);
+     * $I->seeEvent('App\MyEvent');
+     * $I->seeEvent(new App\Events\MyEvent());
+     * $I->seeEvent(['App\MyEvent', 'App\MyOtherEvent']);
      * ```
      *
      * @param object|string|string[] $expected
      */
-    public function seeEventTriggered(array|object|string $expected): void
+    public function seeEvent(array|object|string $expected): void
     {
         $eventCollector = $this->grabEventCollector(__FUNCTION__);
 
@@ -116,6 +157,47 @@ trait EventsAssertionsTrait
         $expected = is_array($expected) ? $expected : [$expected];
 
         $this->assertEventTriggered($data, $expected);
+    }
+
+    /**
+     * Verifies that one or more event listeners were called during the test.
+     *
+     * ```php
+     * <?php
+     * $I->seeEventTriggered('App\MyEventSubscriber');
+     * $I->seeEventTriggered(new App\Events\MyEventSubscriber());
+     * $I->seeEventTriggered(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
+     * ```
+     *
+     * @param object|string|string[] $expected
+     * @deprecated Use `seeEventListenerCalled` instead.
+     */
+    public function seeEventTriggered(array|object|string $expected): void
+    {
+        $this->seeEventListenerCalled($expected);
+    }
+
+    /**
+     * Verifies that one or more event listeners were called during the test.
+     *
+     * ```php
+     * <?php
+     * $I->seeEventListenerCalled('App\MyEventSubscriber');
+     * $I->seeEventListenerCalled(new App\Events\MyEventSubscriber());
+     * $I->seeEventListenerCalled(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
+     * ```
+     *
+     * @param object|string|string[] $expected
+     */
+    public function seeEventListenerCalled(array|object|string $expected): void
+    {
+        $eventCollector = $this->grabEventCollector(__FUNCTION__);
+
+        /** @var Data $data */
+        $data = $eventCollector->getCalledListeners();
+        $expected = is_array($expected) ? $expected : [$expected];
+
+        $this->assertListenerCalled($data, $expected);
     }
 
     protected function assertEventNotTriggered(Data $data, array $expected): void
@@ -127,6 +209,19 @@ trait EventsAssertionsTrait
             $this->assertFalse(
                 $this->eventWasTriggered($actual, (string)$expectedEvent),
                 "The '{$expectedEvent}' event triggered"
+            );
+        }
+    }
+
+    protected function assertListenerNotCalled(Data $data, array $expected): void
+    {
+        $actual = $data->getValue(true);
+
+        foreach ($expected as $expectedListener) {
+            $expectedListener = is_object($expectedListener) ? $expectedListener::class : $expectedListener;
+            $this->assertFalse(
+                $this->listenerWasCalled($actual, (string)$expectedListener),
+                "The '{$expectedListener}' listener was called"
             );
         }
     }
@@ -148,22 +243,49 @@ trait EventsAssertionsTrait
         }
     }
 
+    protected function assertListenerCalled(Data $data, array $expected): void
+    {
+        if ($data->count() === 0) {
+            $this->fail('No listener was called');
+        }
+
+        $actual = $data->getValue(true);
+
+        foreach ($expected as $expectedListener) {
+            $expectedListener = is_object($expectedListener) ? $expectedListener::class : $expectedListener;
+            $this->assertTrue(
+                $this->listenerWasCalled($actual, (string) $expectedListener),
+                "The '{$expectedListener}' listener was not called"
+            );
+        }
+    }
+
     protected function eventWasTriggered(array $actual, string $expectedEvent): bool
     {
-        $triggered = false;
-
         foreach ($actual as $actualEvent) {
             if (is_array($actualEvent)) { // Called Listeners
-                if (str_starts_with($actualEvent['pretty'], $expectedEvent)) {
-                    $triggered = true;
+                if ($actualEvent['event'] === $expectedEvent) {
+                    return true;
                 }
             } else { // Orphan Events
                 if ($actualEvent === $expectedEvent) {
-                    $triggered = true;
+                    return true;
                 }
             }
         }
-        return $triggered;
+
+        return false;
+    }
+
+    protected function listenerWasCalled(array $actual, string $expectedListener): bool
+    {
+        foreach ($actual as $actualEvent) {
+            if (str_starts_with($actualEvent['pretty'], $expectedListener)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected function grabEventCollector(string $function): EventDataCollector

--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -46,7 +46,7 @@ trait EventsAssertionsTrait
     }
 
     /**
-     * Verifies that one or more events were not dispatched during the test.
+     * Verifies that one or more event listeners were not called during the test.
      *
      * ```php
      * <?php
@@ -57,7 +57,7 @@ trait EventsAssertionsTrait
      *
      * @param object|string|string[] $expected
      */
-    public function dontSeeEvent(array|object|string $expected): void
+    public function dontSeeEventTriggered(array|object|string $expected): void
     {
         $eventCollector = $this->grabEventCollector(__FUNCTION__);
 
@@ -66,47 +66,6 @@ trait EventsAssertionsTrait
         $expected = is_array($expected) ? $expected : [$expected];
 
         $this->assertEventNotTriggered($data, $expected);
-    }
-
-    /**
-     * Verifies that one or more event listeners were not called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->dontSeeEventTriggered('App\MyEventSubscriber');
-     * $I->dontSeeEventTriggered(new App\Events\MyEventSubscriber());
-     * $I->dontSeeEventTriggered(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
-     * ```
-     *
-     * @param object|string|string[] $expected
-     * @deprecated Use `dontSeeEventListenerCalled` instead.
-     */
-    public function dontSeeEventTriggered(array|object|string $expected): void
-    {
-        $this->dontSeeEventListenerCalled($expected);
-    }
-
-    /**
-     * Verifies that one or more event listeners were not called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->dontSeeEventListenerCalled('App\MyEventSubscriber');
-     * $I->dontSeeEventListenerCalled(new App\Events\MyEventSubscriber());
-     * $I->dontSeeEventListenerCalled(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
-     * ```
-     *
-     * @param object|string|string[] $expected
-     */
-    public function dontSeeEventListenerCalled(array|object|string $expected): void
-    {
-        $eventCollector = $this->grabEventCollector(__FUNCTION__);
-
-        /** @var Data $data */
-        $data = $eventCollector->getCalledListeners();
-        $expected = is_array($expected) ? $expected : [$expected];
-
-        $this->assertListenerNotCalled($data, $expected);
     }
 
     /**
@@ -137,18 +96,18 @@ trait EventsAssertionsTrait
     }
 
     /**
-     * Verifies that one or more events were dispatched during the test.
+     * Verifies that one or more event listeners were called during the test.
      *
      * ```php
      * <?php
-     * $I->seeEvent('App\MyEvent');
-     * $I->seeEvent(new App\Events\MyEvent());
-     * $I->seeEvent(['App\MyEvent', 'App\MyOtherEvent']);
+     * $I->seeEventTriggered('App\MyEvent');
+     * $I->seeEventTriggered(new App\Events\MyEvent());
+     * $I->seeEventTriggered(['App\MyEvent', 'App\MyOtherEvent']);
      * ```
      *
      * @param object|string|string[] $expected
      */
-    public function seeEvent(array|object|string $expected): void
+    public function seeEventTriggered(array|object|string $expected): void
     {
         $eventCollector = $this->grabEventCollector(__FUNCTION__);
 
@@ -157,47 +116,6 @@ trait EventsAssertionsTrait
         $expected = is_array($expected) ? $expected : [$expected];
 
         $this->assertEventTriggered($data, $expected);
-    }
-
-    /**
-     * Verifies that one or more event listeners were called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->seeEventTriggered('App\MyEventSubscriber');
-     * $I->seeEventTriggered(new App\Events\MyEventSubscriber());
-     * $I->seeEventTriggered(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
-     * ```
-     *
-     * @param object|string|string[] $expected
-     * @deprecated Use `seeEventListenerCalled` instead.
-     */
-    public function seeEventTriggered(array|object|string $expected): void
-    {
-        $this->seeEventListenerCalled($expected);
-    }
-
-    /**
-     * Verifies that one or more event listeners were called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->seeEventListenerCalled('App\MyEventSubscriber');
-     * $I->seeEventListenerCalled(new App\Events\MyEventSubscriber());
-     * $I->seeEventListenerCalled(['App\MyEventSubscriber', 'App\MyOtherEventSubscriber']);
-     * ```
-     *
-     * @param object|string|string[] $expected
-     */
-    public function seeEventListenerCalled(array|object|string $expected): void
-    {
-        $eventCollector = $this->grabEventCollector(__FUNCTION__);
-
-        /** @var Data $data */
-        $data = $eventCollector->getCalledListeners();
-        $expected = is_array($expected) ? $expected : [$expected];
-
-        $this->assertListenerCalled($data, $expected);
     }
 
     protected function assertEventNotTriggered(Data $data, array $expected): void
@@ -209,19 +127,6 @@ trait EventsAssertionsTrait
             $this->assertFalse(
                 $this->eventWasTriggered($actual, (string)$expectedEvent),
                 "The '{$expectedEvent}' event triggered"
-            );
-        }
-    }
-
-    protected function assertListenerNotCalled(Data $data, array $expected): void
-    {
-        $actual = $data->getValue(true);
-
-        foreach ($expected as $expectedListener) {
-            $expectedListener = is_object($expectedListener) ? $expectedListener::class : $expectedListener;
-            $this->assertFalse(
-                $this->listenerWasCalled($actual, (string)$expectedListener),
-                "The '{$expectedListener}' listener was called"
             );
         }
     }
@@ -243,49 +148,22 @@ trait EventsAssertionsTrait
         }
     }
 
-    protected function assertListenerCalled(Data $data, array $expected): void
-    {
-        if ($data->count() === 0) {
-            $this->fail('No listener was called');
-        }
-
-        $actual = $data->getValue(true);
-
-        foreach ($expected as $expectedListener) {
-            $expectedListener = is_object($expectedListener) ? $expectedListener::class : $expectedListener;
-            $this->assertTrue(
-                $this->listenerWasCalled($actual, (string) $expectedListener),
-                "The '{$expectedListener}' listener was not called"
-            );
-        }
-    }
-
     protected function eventWasTriggered(array $actual, string $expectedEvent): bool
     {
+        $triggered = false;
+
         foreach ($actual as $actualEvent) {
             if (is_array($actualEvent)) { // Called Listeners
-                if ($actualEvent['event'] === $expectedEvent) {
-                    return true;
+                if (str_starts_with($actualEvent['pretty'], $expectedEvent)) {
+                    $triggered = true;
                 }
             } else { // Orphan Events
                 if ($actualEvent === $expectedEvent) {
-                    return true;
+                    $triggered = true;
                 }
             }
         }
-
-        return false;
-    }
-
-    protected function listenerWasCalled(array $actual, string $expectedListener): bool
-    {
-        foreach ($actual as $actualEvent) {
-            if (str_starts_with($actualEvent['pretty'], $expectedListener)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $triggered;
     }
 
     protected function grabEventCollector(string $function): EventDataCollector


### PR DESCRIPTION
Hi! Currently, `seeEventTriggered` and `dontSeeEventTriggered` are actually checking if Event Listener was called. 

So I've marked these methods as deprecated and created new ones for the Listeners with more intuitive names:
* `seeEventListenerCalled`
* `dontSeeEventListenerCalled`

Additionally, I've added methods to check if Events were dispatched (named them in a way like `seeOrphanEvent`):
* `seeEvent`
* `dontSeeEvent`

[Tests](https://github.com/Codeception/symfony-module-tests/compare/main...xEdelweiss:symfony-module-tests:new_event_assertions) can be updated if you approve this PR.