### PR TITLE
Ignore fragments when checking routes

### DIFF
--- a/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
@@ -117,6 +117,7 @@ trait RouterAssertionsTrait
         }
 
         $uri = explode('?', $this->grabFromCurrentUrl())[0];
+        $uri = explode('#', $uri)[0];
         $match = [];
         try {
             $match = $router->match($uri);
@@ -147,6 +148,7 @@ trait RouterAssertionsTrait
         }
 
         $uri = explode('?', $this->grabFromCurrentUrl())[0];
+        $uri = explode('#', $uri)[0];
         $matchedRouteName = '';
         try {
             $matchedRouteName = (string)$router->match($uri)['_route'];


### PR DESCRIPTION
The following test fails:

```php
$I->amOnRoute('payment_history', ['month' => '2020-07', '_fragment' => 'content']);
$I->seeCurrentRouteIs('payment_history');
```

With:

```
Step  See current route is "payment_history"
Fail  The "/payment-history/2020-07#content" url does not match with any route
```