### PR TITLE
Require bootstrap.php if exists, to load all necessary .env files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/config": "^5.4 | ^6.4 | ^7.0",
         "symfony/dependency-injection": "^5.4 | ^6.4 | ^7.0",
         "symfony/dom-crawler": "^5.4 | ^6.4 | ^7.0",
+        "symfony/dotenv": "^5.4 | ^6.4 | ^7.0",
         "symfony/error-handler": "^5.4 | ^6.4 | ^7.0",
         "symfony/filesystem": "^5.4 | ^6.4 | ^7.0",
         "symfony/form": "^5.4 | ^6.4 | ^7.0",

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -86,6 +86,7 @@ use function sprintf;
  * * `cache_router`: 'false' - Enable router caching between tests in order to [increase performance](http://lakion.com/blog/how-did-we-speed-up-sylius-behat-suite-with-blackfire)
  * * `rebootable_client`: 'true' - Reboot client's kernel before each request
  * * `guard`: 'false' - Enable custom authentication system with guard (only for Symfony 5.4)
+ * * `bootstrap`: 'false' - Enable the test environment setup with the tests/bootstrap.php file if it exists or with Symfony DotEnv otherwise. If false, it does nothing.
  * * `authenticator`: 'false' - Reboot client's kernel before each request (only for Symfony 6.0 or higher)
  *
  * #### Sample `Functional.suite.yml`
@@ -169,6 +170,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         'em_service' => 'doctrine.orm.entity_manager',
         'rebootable_client' => true,
         'authenticator' => false,
+        'bootstrap' => false,
         'guard' => false
     ];
 
@@ -206,7 +208,9 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         }
 
         $this->kernel = new $this->kernelClass($this->config['environment'], $this->config['debug']);
-        $this->bootstrapEnvironment();
+        if($this->config['bootstrap']) {
+            $this->bootstrapEnvironment();
+        }
         $this->kernel->boot();
 
         if ($this->config['cache_router'] === true) {


### PR DESCRIPTION
I'm replacing #4 with this.

In my last comment I expressed that I had problems with compatibility logic in lower versions of Symfony, but since the minimum compatible version is now 5.4 we can move on.
I require the `tests/bootstrap.php` file if it exists, otherwise I try to use dotEnv manually.
If all that fails I throw an exception telling the user what to do.

In the tests I performed this works regardless of whether or not you have `.env` and `.env.test` set in `codeception.yml`. 
This will also allow to remove these values from the [recipe](https://github.com/symfony/recipes-contrib/blob/8f56f2cee929025a5597b9e44d81fe90c4e7cd71/codeception/codeception/5.0/codeception.yml#L15) since they are now loaded automatically.

Closes #99.