### PR TITLE
Update ParameterAssertionsTrait.php: Adding info about `bind`

### DIFF
--- a/src/Codeception/Module/Symfony/ParameterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ParameterAssertionsTrait.php
@@ -16,6 +16,7 @@ trait ParameterAssertionsTrait
      * <?php
      * $I->grabParameter('app.business_name');
      * ```
+     * This only works for explicitly set parameters (just using `bind` for Symfony's dependency injection is not enough).
      */
     public function grabParameter(string $parameterName): array|bool|string|int|float|UnitEnum|null
     {


### PR DESCRIPTION
I hardly have any parameters `set`, I define most of them via `bind`. That's why I'm adding this.

There is no way to grab a `bind`-Parameter, right?