### PR TITLE
Declare nullable parameter types explicitly for PHP 8.4 compatibility

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -335,7 +335,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     /**
      * Grabs a Symfony Data Collector
      */
-    protected function grabCollector(string $collector, string $function, string $message = null): DataCollectorInterface
+    protected function grabCollector(string $collector, string $function, ?string $message = null): DataCollectorInterface
     {
         $profile = $this->getProfile();
         if ($profile === null) {

--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -43,7 +43,7 @@ trait BrowserAssertionsTrait
      *
      * @param string|null $url
      */
-    public function seePageIsAvailable(string $url = null): void
+    public function seePageIsAvailable(?string $url = null): void
     {
         if ($url !== null) {
             $this->amOnPage($url);

--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -23,7 +23,7 @@ trait EventsAssertionsTrait
      *
      * @param string|string[]|null $expected
      */
-    public function dontSeeEvent(array|string $expected = null): void
+    public function dontSeeEvent(array|string|null $expected = null): void
     {
         $actualEvents = [...array_column($this->getCalledListeners(), 'event')];
         $actual = [$this->getOrphanedEvents(), $actualEvents];
@@ -87,7 +87,7 @@ trait EventsAssertionsTrait
      *
      * @param string|string[] $expected
      */
-    public function dontSeeOrphanEvent(array|string $expected = null): void
+    public function dontSeeOrphanEvent(array|string|null $expected = null): void
     {
         $actual = [$this->getOrphanedEvents()];
         $this->assertEventTriggered(false, $expected, $actual);

--- a/src/Codeception/Module/Symfony/FormAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/FormAssertionsTrait.php
@@ -45,7 +45,7 @@ trait FormAssertionsTrait
      *
      * @param string|null $message
      */
-    public function seeFormErrorMessage(string $field, string $message = null): void
+    public function seeFormErrorMessage(string $field, ?string $message = null): void
     {
         $formCollector = $this->grabFormCollector(__FUNCTION__);
 

--- a/src/Codeception/Module/Symfony/MimeAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MimeAssertionsTrait.php
@@ -20,7 +20,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailAddressContains('To', 'jane_doe@example.com');
      * ```
      */
-    public function assertEmailAddressContains(string $headerName, string $expectedValue, Email $email = null): void
+    public function assertEmailAddressContains(string $headerName, string $expectedValue, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new MimeConstraint\EmailAddressContains($headerName, $expectedValue));
@@ -35,7 +35,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailAttachmentCount(1);
      * ```
      */
-    public function assertEmailAttachmentCount(int $count, Email $email = null): void
+    public function assertEmailAttachmentCount(int $count, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new MimeConstraint\EmailAttachmentCount($count));
@@ -50,7 +50,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailHasHeader('Bcc');
      * ```
      */
-    public function assertEmailHasHeader(string $headerName, Email $email = null): void
+    public function assertEmailHasHeader(string $headerName, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new MimeConstraint\EmailHasHeader($headerName));
@@ -66,7 +66,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailHeaderNotSame('To', 'john_doe@gmail.com');
      * ```
      */
-    public function assertEmailHeaderNotSame(string $headerName, string $expectedValue, Email $email = null): void
+    public function assertEmailHeaderNotSame(string $headerName, string $expectedValue, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new LogicalNot(new MimeConstraint\EmailHeaderSame($headerName, $expectedValue)));
@@ -82,7 +82,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailHeaderSame('To', 'jane_doe@gmail.com');
      * ```
      */
-    public function assertEmailHeaderSame(string $headerName, string $expectedValue, Email $email = null): void
+    public function assertEmailHeaderSame(string $headerName, string $expectedValue, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new MimeConstraint\EmailHeaderSame($headerName, $expectedValue));
@@ -97,7 +97,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailHtmlBodyContains('Successful registration');
      * ```
      */
-    public function assertEmailHtmlBodyContains(string $text, Email $email = null): void
+    public function assertEmailHtmlBodyContains(string $text, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new MimeConstraint\EmailHtmlBodyContains($text));
@@ -112,7 +112,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailHtmlBodyNotContains('userpassword');
      * ```
      */
-    public function assertEmailHtmlBodyNotContains(string $text, Email $email = null): void
+    public function assertEmailHtmlBodyNotContains(string $text, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new LogicalNot(new MimeConstraint\EmailHtmlBodyContains($text)));
@@ -127,7 +127,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailNotHasHeader('Bcc');
      * ```
      */
-    public function assertEmailNotHasHeader(string $headerName, Email $email = null): void
+    public function assertEmailNotHasHeader(string $headerName, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new LogicalNot(new MimeConstraint\EmailHasHeader($headerName)));
@@ -142,7 +142,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailTextBodyContains('Example text body');
      * ```
      */
-    public function assertEmailTextBodyContains(string $text, Email $email = null): void
+    public function assertEmailTextBodyContains(string $text, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new MimeConstraint\EmailTextBodyContains($text));
@@ -157,7 +157,7 @@ trait MimeAssertionsTrait
      * $I->assertEmailTextBodyNotContains('My secret text body');
      * ```
      */
-    public function assertEmailTextBodyNotContains(string $text, Email $email = null): void
+    public function assertEmailTextBodyNotContains(string $text, ?Email $email = null): void
     {
         $email = $this->verifyEmailObject($email, __FUNCTION__);
         $this->assertThat($email, new LogicalNot(new MimeConstraint\EmailTextBodyContains($text)));

--- a/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
@@ -163,7 +163,7 @@ trait SecurityAssertionsTrait
      *
      * @param UserInterface|null $user
      */
-    public function seeUserPasswordDoesNotNeedRehash(UserInterface $user = null): void
+    public function seeUserPasswordDoesNotNeedRehash(?UserInterface $user = null): void
     {
         if ($user === null) {
             $security = $this->grabSecurityService();

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -35,13 +35,13 @@ trait SessionAssertionsTrait
      * $I->amLoggedInAs($user);
      * ```
      */
-    public function amLoggedInAs(UserInterface $user, string $firewallName = 'main', string $firewallContext = null): void
+    public function amLoggedInAs(UserInterface $user, string $firewallName = 'main', ?string $firewallContext = null): void
     {
         $token = $this->createAuthenticationToken($user, $firewallName);
         $this->loginWithToken($token, $firewallName, $firewallContext);
     }
 
-    public function amLoggedInWithToken(TokenInterface $token, string $firewallName = 'main', string $firewallContext = null): void
+    public function amLoggedInWithToken(TokenInterface $token, string $firewallName = 'main', ?string $firewallContext = null): void
     {
         $this->loginWithToken($token, $firewallName, $firewallContext);
     }


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types deprecates implicitly nullable parameter types in PHP 8.4