### PR TITLE
Added Symfony Logger assertion (dontSeeDeprecations)

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -17,6 +17,7 @@ use Codeception\Module\Symfony\DomCrawlerAssertionsTrait;
 use Codeception\Module\Symfony\EventsAssertionsTrait;
 use Codeception\Module\Symfony\FormAssertionsTrait;
 use Codeception\Module\Symfony\HttpClientAssertionsTrait;
+use Codeception\Module\Symfony\LoggerAssertionsTrait;
 use Codeception\Module\Symfony\MailerAssertionsTrait;
 use Codeception\Module\Symfony\MimeAssertionsTrait;
 use Codeception\Module\Symfony\ParameterAssertionsTrait;
@@ -142,6 +143,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     use EventsAssertionsTrait;
     use FormAssertionsTrait;
     use HttpClientAssertionsTrait;
+    use LoggerAssertionsTrait;
     use MailerAssertionsTrait;
     use MimeAssertionsTrait;
     use ParameterAssertionsTrait;

--- a/src/Codeception/Module/Symfony/LoggerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/LoggerAssertionsTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Module\Symfony;
+
+use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
+use function sprintf;
+
+trait LoggerAssertionsTrait
+{
+    /**
+     * Asserts that there are no deprecation messages in Symfony's log.
+     *
+     * ```php
+     * <?php
+     * $I->amOnPage('/home');
+     * $I->dontSeeDeprecations();
+     * ```
+     *
+     * @param string $message Optional custom failure message.
+     */
+    public function dontSeeDeprecations(string $message = ''): void
+    {
+        $loggerCollector = $this->grabLoggerCollector(__FUNCTION__);
+        $logs = $loggerCollector->getProcessedLogs();
+
+        $foundDeprecations = [];
+
+        foreach ($logs as $log) {
+            if (isset($log['type']) && $log['type'] === 'deprecation') {
+                $msg = $log['message'];
+                if ($msg instanceof Data) {
+                    $msg = $msg->getValue(true);
+                }
+                if (!is_string($msg)) {
+                    $msg = (string)$msg;
+                }
+                $foundDeprecations[] = $msg;
+            }
+        }
+
+        $errorMessage = $message ?: sprintf(
+            "Found %d deprecation message%s in the log:\n%s",
+            count($foundDeprecations),
+            count($foundDeprecations) > 1 ? 's' : '',
+            implode("\n", array_map(static function ($msg) {
+                return "  - " . $msg;
+            }, $foundDeprecations))
+        );
+
+        $this->assertEmpty($foundDeprecations, $errorMessage);
+    }
+
+    protected function grabLoggerCollector(string $function): LoggerDataCollector
+    {
+        return $this->grabCollector('logger', $function);
+    }
+}


### PR DESCRIPTION

```php
       $I->amOnPage('/home');
       $I->dontSeeDeprecations();
```

```cmd
 Step  Don't see deprecations
 Fail  Found 2 deprecation messages in the log:
  - Since doctrine/doctrine-bundle 2.12: The default value of "doctrine.orm.controller_resolver.auto_mapping" will be changed from `true` to `false`...
  - Since doctrine/doctrine-bundle 2.13: Enabling the controller resolver automapping feature has been deprecated....
Failed asserting that an array is empty.

```