### PR TITLE
Replace kernel reboot with actual boot to reset services

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -31,18 +31,16 @@ class Symfony extends HttpKernelBrowser
         parent::__construct($kernel);
         $this->followRedirects();
         $this->container = $this->getContainer();
-        $this->rebootKernel();
+        $this->rebootKernel(); // Ensure the profiler exists
     }
 
     /** @param Request $request */
     protected function doRequest(object $request): Response
     {
-        if ($this->rebootable) {
-            if ($this->hasPerformedRequest) {
-                $this->rebootKernel();
-            } else {
-                $this->hasPerformedRequest = true;
-            }
+        if ($this->hasPerformedRequest && $this->rebootable) {
+            $this->rebootKernel();
+        } else {
+            $this->hasPerformedRequest = true;
         }
 
         return parent::doRequest($request);
@@ -66,7 +64,9 @@ class Symfony extends HttpKernelBrowser
         }
 
         $this->persistDoctrineConnections();
-        $this->kernel->reboot(null);
+        $this->kernel->boot();
+        $this->kernel->shutdown();
+        $this->kernel->boot();
         $this->container = $this->getContainer();
 
         foreach ($this->persistentServices as $serviceName => $service) {


### PR DESCRIPTION
Hi,
we are using codeception in our api-platform project and atm we are blocked because of https://github.com/symfony/symfony/issues/59036. It got resolved for users of phpunit with WebTestCase tests but in codeception we are still struggling with this. I debugged this and compared both the same workflow of tests in codeception and phpunit. There I noticed that in \Symfony\Bundle\FrameworkBundle\KernelBrowser::doRequest the kernel is booted and shut down before the request and in codeception the kernel is just rebooted without calling the function to reset all resettable services. This change should fix this and ensure, that the requests formats are in a valid state before each request. I'll try to provide a test for this later on. For now I just ensured that current tests are not breaking