### PR TITLE
Update ServicesAssertionsTrait.php: Adding another hint about private…

### DIFF
--- a/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
@@ -10,9 +10,9 @@ trait ServicesAssertionsTrait
 {
     /**
      * Grabs a service from the Symfony dependency injection container (DIC).
-     * In "test" environment, Symfony uses a special `test.service_container`.
+     * In the "test" environment, Symfony uses a special `test.service_container`.
      * See the "[Public Versus Private Services](https://symfony.com/doc/current/service_container/alias_private.html#marking-services-as-public-private)" documentation.
-     * Services that aren't injected somewhere into your app, need to be defined as `public` to be accessible by Codeception.
+     * Services that aren't injected anywhere in your app, need to be defined as `public` to be accessible by Codeception.
      *
      * ```php
      * <?php
@@ -25,7 +25,8 @@ trait ServicesAssertionsTrait
     {
         if (!$service = $this->getService($serviceId)) {
             $this->fail("Service `{$serviceId}` is required by Codeception, but not loaded by Symfony since you're not using it anywhere in your app.\n
-            Recommended solution: Set it to `public` in your `config/services_test.php`/`.yaml`, see https://symfony.com/doc/current/service_container/alias_private.html#marking-services-as-public-private");
+            Recommended solution: Set it to `public` in your `config/services.php`/`.yaml`, see https://symfony.com/doc/current/service_container/alias_private.html#marking-services-as-public-private\n
+            Besides, `test` needs to be set to `true` in your `config/packages/framework.php`/`.yaml`, see https://symfony.com/doc/current/reference/configuration/framework.html#test");
         }
 
         return $service;


### PR DESCRIPTION
… services

If this setting is missing, `test.private_services_locator` isn't loaded. Just encountered this problem in one of my projects...