### PR TITLE
Fix profiler service deprecation by using non-deprecated internal id

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -87,13 +87,15 @@ class Symfony extends HttpKernelBrowser
 
     private function getProfiler(): ?Profiler
     {
-        if (!$this->container->has('profiler')) {
-            return null;
+        foreach (['.container.private.profiler', 'profiler'] as $id) {
+            if ($this->container->has($id)) {
+                $profiler = $this->container->get($id);
+
+                return $profiler instanceof Profiler ? $profiler : null;
+            }
         }
 
-        $profiler = $this->container->get('profiler');
-
-        return $profiler instanceof Profiler ? $profiler : null;
+        return null;
     }
 
     private function persistDoctrineConnections(): void

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -364,8 +364,7 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     protected function getProfile(): ?Profile
     {
-        /** @var Profiler|null $profiler */
-        $profiler = $this->getService('profiler');
+        $profiler = $this->grabCachedService(Profiler::class, ['.container.private.profiler', 'profiler']);
 
         if ($profiler === null) {
             return null;

--- a/tests/Support/CodeceptTestCase.php
+++ b/tests/Support/CodeceptTestCase.php
@@ -153,12 +153,20 @@ abstract class CodeceptTestCase extends TestCase
         }
 
         $container = $this->_getContainer();
-        if (!$container->has('profiler')) {
+
+        $profiler = null;
+        foreach (['.container.private.profiler', 'profiler'] as $id) {
+            if ($container->has($id)) {
+                /** @var Profiler $profiler */
+                $profiler = $container->get($id);
+                break;
+            }
+        }
+
+        if (!$profiler instanceof Profiler) {
             return null;
         }
 
-        /** @var Profiler $profiler */
-        $profiler = $container->get('profiler');
         $profile = $profiler->collect($request, $response);
 
         if ($profile instanceof Profile) {


### PR DESCRIPTION
## Problem

Running tests with the module triggers a deprecation (issue #212, reported by @ostrolucky):

> Accessing the "profiler" service directly from the container is deprecated, use dependency injection instead.

Since `symfony/framework-bundle` 5.4 the `profiler` service is declared `->public()->tag('container.private', ..., '5.4')`. `AliasDeprecatedPublicServicesPass` turns the public id `profiler` into a **deprecated alias** whose generated factory calls `trigger_deprecation()` before delegating to the real, non-deprecated definition `.container.private.profiler`:

```php
protected static function getProfilerService($container) {                 // id 'profiler'
    trigger_deprecation('symfony/framework-bundle', '5.4',
        'Accessing the "profiler" service directly from the container is deprecated, use dependency injection instead.');
    return $container->get('.container.private.profiler');
}
protected static function get_Container_Private_ProfilerService($container) { // NO trigger_deprecation
    ...
}
```

## Fix

Prefer the non-deprecated internal id `.container.private.profiler`, falling back to `profiler` for older/edge configs where the deprecated alias does not exist. The internal id lives in the container `methodMap`, so `has()`/`get()` resolve it cleanly on **both** the raw kernel container and the `test.service_container`, across Symfony 5.4 → 8.0.

Changed:
- `src/Codeception/Lib/Connector/Symfony.php` — `getProfiler()`
- `src/Codeception/Module/Symfony.php` — `getProfile()`
- `tests/Support/CodeceptTestCase.php` — same resolution, for consistency

## Verification

- `vendor/bin/phpunit tests` — 142 passing (1 pre-existing skip); profiler-dependent `MailerAssertionsTest` green.
- `composer phpstan` (level max) — no new errors.

A companion functional test will follow in [Codeception/symfony-module-tests](https://github.com/Codeception/symfony-module-tests) per `CONTRIBUTING.md`.

Closes #212
