### PR TITLE
Restore InnerBrowser navigation state for Codeception runs (#231)

### DIFF
--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Lib\InnerBrowser;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
@@ -22,7 +23,6 @@ use Symfony\Component\HttpFoundation\Test\Constraint\ResponseIsUnprocessable;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseStatusCodeSame;
 
 use function class_exists;
-use function count;
 use function sprintf;
 
 trait BrowserAssertionsTrait
@@ -318,8 +318,15 @@ trait BrowserAssertionsTrait
     public function seePageIsAvailable(?string $url = null): void
     {
         if ($url !== null) {
-            $this->getClient()->request('GET', $url);
-            $this->assertStringContainsString($url, $this->getClient()->getRequest()->getRequestUri());
+            $client = $this->getClient();
+
+            if ($this instanceof InnerBrowser) {
+                $this->amOnPage($url);
+            } else {
+                $client->request('GET', $url);
+            }
+
+            $this->assertStringContainsString($url, $client->getRequest()->getRequestUri());
         }
 
         $this->assertResponseIsSuccessful();
@@ -337,7 +344,12 @@ trait BrowserAssertionsTrait
     {
         $client = $this->getClient();
         $client->followRedirects(false);
-        $client->request('GET', $page);
+
+        if ($this instanceof InnerBrowser) {
+            $this->amOnPage($page);
+        } else {
+            $client->request('GET', $page);
+        }
 
         $this->assertThatForResponse(new ResponseIsRedirected(), 'The response is not a redirection.');
 
@@ -364,6 +376,7 @@ trait BrowserAssertionsTrait
      */
     public function submitSymfonyForm(string $name, array $fields): void
     {
+        $client = $this->getClient();
         $selector = sprintf('form[name=%s]', $name);
 
         $params = [];
@@ -371,10 +384,16 @@ trait BrowserAssertionsTrait
             $params[$name . $key] = $value;
         }
 
-        $node = $this->getClient()->getCrawler()->filter($selector);
-        $this->assertGreaterThan(0, count($node), sprintf('Form "%s" not found.', $selector));
+        if ($this instanceof InnerBrowser) {
+            $this->submitForm($selector, $params, sprintf('%s_submit', $name));
+
+            return;
+        }
+
+        $node = $client->getCrawler()->filter($selector);
+        $this->assertGreaterThan(0, $node->count(), sprintf('Form "%s" not found.', $selector));
         $form = $node->form();
-        $this->getClient()->submit($form, $params);
+        $client->submit($form, $params);
     }
 
     protected function assertThatForClient(Constraint $constraint, string $message = ''): void

--- a/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Lib\InnerBrowser;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -157,7 +158,16 @@ trait RouterAssertionsTrait
     /** @param array<string, mixed> $params */
     private function openRoute(string $routeName, array $params = []): void
     {
-        $this->getClient()->request('GET', $this->grabRouterService()->generate($routeName, $params));
+        $client = $this->getClient();
+        $url = $this->grabRouterService()->generate($routeName, $params);
+
+        if ($this instanceof InnerBrowser) {
+            $this->amOnPage($url);
+
+            return;
+        }
+
+        $client->request('GET', $url);
     }
 
     protected function grabRouterService(): RouterInterface


### PR DESCRIPTION
Fixes #231. Targets `3.9.x` for a 3.9.2 bugfix release.

## Problem

The 3.9.0 "Performance Optimizations and Code Audit" decoupled four steps from `codeception/lib-innerbrowser` so they can also run from plain PHPUnit test cases:

- `amOnRoute()` / `amOnAction()` (via `openRoute()`)
- `seePageIsAvailable()`
- `seePageRedirectsTo()`
- `submitSymfonyForm()`

They were switched from `amOnPage()` / `submitForm()` to driving the BrowserKit client directly (`$client->request()` / `$client->submit()`), discarding the returned `Crawler`.

Under Codeception that broke downstream assertions: only `InnerBrowser::_loadPage()` writes the returned `Crawler` back into the cached `$crawler` (and resets `$baseUrl` / `$forms`). After these methods the module's crawler stayed `null` or stale, so `see()`, `click()`, and the form helpers failed with "Crawler is null" or asserted against the previous page. Worked on 3.8.0, broke on 3.9.0 / 3.9.1.

## Fix (keeps the decoupling)

Each of the four methods now branches on the runner with a capability check (`$this instanceof InnerBrowser`):

- Under Codeception (the module **is** an `InnerBrowser`), navigation/submission is delegated to `amOnPage()` / `submitForm()` so the cached crawler state stays in sync.
- Otherwise (plain PHPUnit, no crawler to maintain), it keeps driving the BrowserKit client directly.

The check is `instanceof`, not `class_exists()`: `lib-innerbrowser` is always installed, so only the instance type distinguishes "running as the Codeception module" from "used as a trait by a PHPUnit `TestCase`".

## Validation

`composer phpstan` (level max) and `composer cs-check` pass; the unit suite stays green. A matching functional test in [Codeception/symfony-module-tests](https://github.com/Codeception/symfony-module-tests) is still needed per `CONTRIBUTING.md` (separate PR).
