### PR TITLE
Restore InnerBrowser navigation state for Codeception runs (#231)

### DIFF
--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Lib\InnerBrowser;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
@@ -319,7 +320,13 @@ trait BrowserAssertionsTrait
     {
         if ($url !== null) {
             $client = $this->getClient();
-            $client->request('GET', $url);
+
+            if ($this instanceof InnerBrowser) {
+                $this->amOnPage($url);
+            } else {
+                $client->request('GET', $url);
+            }
+
             $this->assertStringContainsString($url, $client->getRequest()->getRequestUri());
         }
 
@@ -338,7 +345,12 @@ trait BrowserAssertionsTrait
     {
         $client = $this->getClient();
         $client->followRedirects(false);
-        $client->request('GET', $page);
+
+        if ($this instanceof InnerBrowser) {
+            $this->amOnPage($page);
+        } else {
+            $client->request('GET', $page);
+        }
 
         $this->assertThatForResponse(new ResponseIsRedirected(), 'The response is not a redirection.');
 
@@ -365,6 +377,7 @@ trait BrowserAssertionsTrait
      */
     public function submitSymfonyForm(string $name, array $fields): void
     {
+        $client = $this->getClient();
         $selector = sprintf('form[name=%s]', $name);
 
         $params = [];
@@ -372,7 +385,12 @@ trait BrowserAssertionsTrait
             $params[$name . $key] = $value;
         }
 
-        $client = $this->getClient();
+        if ($this instanceof InnerBrowser) {
+            $this->submitForm($selector, $params, sprintf('%s_submit', $name));
+
+            return;
+        }
+
         $node = $client->getCrawler()->filter($selector);
         $this->assertGreaterThan(0, $node->count(), sprintf('Form "%s" not found.', $selector));
         $form = $node->form();

--- a/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Lib\InnerBrowser;
 use PHPUnit\Framework\Assert;
 use Stringable;
 use Symfony\Component\Routing\RouterInterface;
@@ -161,7 +162,16 @@ trait RouterAssertionsTrait
     /** @param array<string, scalar|Stringable|array<mixed>|null> $params */
     private function openRoute(string $routeName, array $params = []): void
     {
-        $this->getClient()->request('GET', $this->grabRouterService()->generate($routeName, $params));
+        $client = $this->getClient();
+        $url = $this->grabRouterService()->generate($routeName, $params);
+
+        if ($this instanceof InnerBrowser) {
+            $this->amOnPage($url);
+
+            return;
+        }
+
+        $client->request('GET', $url);
     }
 
     protected function grabRouterService(): RouterInterface


### PR DESCRIPTION
Fixes #231 on `main` (companion to the 3.9.x backport #238).

## Problem

The 3.9.0 audit decoupled four steps from `codeception/lib-innerbrowser` so they can also run from plain PHPUnit test cases — `amOnRoute()` / `amOnAction()` (via `openRoute()`), `seePageIsAvailable()`, `seePageRedirectsTo()`, `submitSymfonyForm()` — switching them from `amOnPage()` / `submitForm()` to driving the BrowserKit client directly and discarding the returned `Crawler`.

Under Codeception only `InnerBrowser::_loadPage()` writes the `Crawler` back into the cached `$crawler` (and resets `$baseUrl` / `$forms`), so after these methods `see()`, `click()` and the form helpers operated on a `null`/stale Crawler. Worked on 3.8.0, broke on 3.9.0 / 3.9.1.

## Fix (keeps the decoupling)

Each method branches on the runner with `$this instanceof InnerBrowser`:

- Under Codeception (the module **is** an `InnerBrowser`) → delegate to `amOnPage()` / `submitForm()` so the cached crawler stays in sync.
- Otherwise (plain PHPUnit) → keep driving the BrowserKit client directly.

`instanceof`, not `class_exists()`: `lib-innerbrowser` is always installed, so only the instance type distinguishes "the Codeception module" from "a trait used by a PHPUnit `TestCase`".

`composer phpstan` (level max) and `composer cs-check` pass; the unit suite stays green. A matching functional test in [Codeception/symfony-module-tests](https://github.com/Codeception/symfony-module-tests) is still needed per `CONTRIBUTING.md`.
