### PR TITLE
Add Symfony-inherited assertions (Browser, DomCrawler, Mailer, Mime)

### DIFF
--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use Symfony\Component\BrowserKit\Test\Constraint\BrowserCookieValueSame;
 use Symfony\Component\BrowserKit\Test\Constraint\BrowserHasCookie;
+use Symfony\Component\BrowserKit\Test\Constraint\BrowserHistoryIsOnFirstPage;
+use Symfony\Component\BrowserKit\Test\Constraint\BrowserHistoryIsOnLastPage;
 use Symfony\Component\HttpFoundation\Test\Constraint\RequestAttributeValueSame;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseCookieValueSame;
 use Symfony\Component\HttpFoundation\Test\Constraint\ResponseFormatSame;
@@ -69,6 +71,78 @@ trait BrowserAssertionsTrait
     public function assertBrowserNotHasCookie(string $name, string $path = '/', ?string $domain = null, string $message = ''): void
     {
         $this->assertThatForClient(new LogicalNot(new BrowserHasCookie($name, $path, $domain)), $message);
+    }
+
+    /**
+     * Asserts that the browser history is currently on the first page.
+     *
+     * ```php
+     * <?php
+     * $I->assertBrowserHistoryIsOnFirstPage();
+     * ```
+     */
+    public function assertBrowserHistoryIsOnFirstPage(string $message = ''): void
+    {
+        $this->assertTrue(
+            class_exists(BrowserHistoryIsOnFirstPage::class),
+            'The assertBrowserHistoryIsOnFirstPage method requires symfony/browser-kit >= 7.4.'
+        );
+
+        $this->assertThatForClient(new BrowserHistoryIsOnFirstPage(), $message);
+    }
+
+    /**
+     * Asserts that the browser history is not currently on the first page.
+     *
+     * ```php
+     * <?php
+     * $I->assertBrowserHistoryIsNotOnFirstPage();
+     * ```
+     */
+    public function assertBrowserHistoryIsNotOnFirstPage(string $message = ''): void
+    {
+        $this->assertTrue(
+            class_exists(BrowserHistoryIsOnFirstPage::class),
+            'The assertBrowserHistoryIsNotOnFirstPage method requires symfony/browser-kit >= 7.4.'
+        );
+
+        $this->assertThatForClient(new LogicalNot(new BrowserHistoryIsOnFirstPage()), $message);
+    }
+
+    /**
+     * Asserts that the browser history is currently on the last page.
+     *
+     * ```php
+     * <?php
+     * $I->assertBrowserHistoryIsOnLastPage();
+     * ```
+     */
+    public function assertBrowserHistoryIsOnLastPage(string $message = ''): void
+    {
+        $this->assertTrue(
+            class_exists(BrowserHistoryIsOnLastPage::class),
+            'The assertBrowserHistoryIsOnLastPage method requires symfony/browser-kit >= 7.4.'
+        );
+
+        $this->assertThatForClient(new BrowserHistoryIsOnLastPage(), $message);
+    }
+
+    /**
+     * Asserts that the browser history is not currently on the last page.
+     *
+     * ```php
+     * <?php
+     * $I->assertBrowserHistoryIsNotOnLastPage();
+     * ```
+     */
+    public function assertBrowserHistoryIsNotOnLastPage(string $message = ''): void
+    {
+        $this->assertTrue(
+            class_exists(BrowserHistoryIsOnLastPage::class),
+            'The assertBrowserHistoryIsNotOnLastPage method requires symfony/browser-kit >= 7.4.'
+        );
+
+        $this->assertThatForClient(new LogicalNot(new BrowserHistoryIsOnLastPage()), $message);
     }
 
     /**

--- a/src/Codeception/Module/Symfony/DomCrawlerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/DomCrawlerAssertionsTrait.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace Codeception\Module\Symfony;
 
 use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerAnySelectorTextContains;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerAnySelectorTextSame;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorAttributeValueSame;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorCount;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorExists;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorTextContains;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorTextSame;
 
+use function class_exists;
 use function sprintf;
 
 trait DomCrawlerAssertionsTrait
@@ -120,6 +125,20 @@ trait DomCrawlerAssertionsTrait
     }
 
     /**
+     * Asserts that the given selector matches the expected number of elements.
+     *
+     * ```php
+     * <?php
+     * $I->assertSelectorCount(3, '.item');
+     * ```
+     */
+    public function assertSelectorCount(int $expectedCount, string $selector, string $message = ''): void
+    {
+        $this->assertDomCrawlerConstraintAvailable(CrawlerSelectorCount::class, __FUNCTION__);
+        $this->assertThatCrawler(new CrawlerSelectorCount($expectedCount, $selector), $message);
+    }
+
+    /**
      * Asserts that the first element matching the given selector contains the expected text.
      *
      * ```php
@@ -133,6 +152,48 @@ trait DomCrawlerAssertionsTrait
     }
 
     /**
+     * Asserts that at least one element matching the given selector contains the expected text.
+     *
+     * ```php
+     * <?php
+     * $I->assertAnySelectorTextContains('.item', 'Available');
+     * ```
+     */
+    public function assertAnySelectorTextContains(string $selector, string $text, string $message = ''): void
+    {
+        $this->assertDomCrawlerConstraintAvailable(CrawlerAnySelectorTextContains::class, __FUNCTION__);
+
+        $this->assertThatCrawler(
+            LogicalAnd::fromConstraints(
+                new CrawlerSelectorExists($selector),
+                new CrawlerAnySelectorTextContains($selector, $text)
+            ),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that at least one element matching the given selector has exactly the expected text.
+     *
+     * ```php
+     * <?php
+     * $I->assertAnySelectorTextSame('.item', 'In stock');
+     * ```
+     */
+    public function assertAnySelectorTextSame(string $selector, string $text, string $message = ''): void
+    {
+        $this->assertDomCrawlerConstraintAvailable(CrawlerAnySelectorTextSame::class, __FUNCTION__);
+
+        $this->assertThatCrawler(
+            LogicalAnd::fromConstraints(
+                new CrawlerSelectorExists($selector),
+                new CrawlerAnySelectorTextSame($selector, $text)
+            ),
+            $message
+        );
+    }
+
+    /**
      * Asserts that the first element matching the given selector does not contain the expected text.
      *
      * ```php
@@ -143,6 +204,27 @@ trait DomCrawlerAssertionsTrait
     public function assertSelectorTextNotContains(string $selector, string $text, string $message = ''): void
     {
         $this->assertThatCrawler(new LogicalNot(new CrawlerSelectorTextContains($selector, $text)), $message);
+    }
+
+    /**
+     * Asserts that no element matching the given selector contains the expected text.
+     *
+     * ```php
+     * <?php
+     * $I->assertAnySelectorTextNotContains('.item', 'Error');
+     * ```
+     */
+    public function assertAnySelectorTextNotContains(string $selector, string $text, string $message = ''): void
+    {
+        $this->assertDomCrawlerConstraintAvailable(CrawlerAnySelectorTextContains::class, __FUNCTION__);
+
+        $this->assertThatCrawler(
+            LogicalAnd::fromConstraints(
+                new CrawlerSelectorExists($selector),
+                new LogicalNot(new CrawlerAnySelectorTextContains($selector, $text))
+            ),
+            $message
+        );
     }
 
     /**
@@ -183,5 +265,17 @@ trait DomCrawlerAssertionsTrait
             $constraint = new LogicalNot($constraint);
         }
         $this->assertThatCrawler($constraint, $context);
+    }
+
+    private function assertDomCrawlerConstraintAvailable(string $constraintClass, string $function): void
+    {
+        $this->assertTrue(
+            class_exists($constraintClass),
+            sprintf(
+                "The '%s' assertion is not available with your installed symfony/dom-crawler version. Missing constraint: %s",
+                $function,
+                $constraintClass
+            )
+        );
     }
 }

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -146,6 +146,21 @@ trait MailerAssertionsTrait
     }
 
     /**
+     * Returns all mailer events for the given transport.
+     *
+     * ```php
+     * <?php
+     * $events = $I->getMailerEvents();
+     * ```
+     *
+     * @return MessageEvent[]
+     */
+    public function getMailerEvents(?string $transport = null): array
+    {
+        return $this->getMessageMailerEvents()->getEvents($transport);
+    }
+
+    /**
      * Returns the mailer event at the specified index.
      *
      * ```php
@@ -155,7 +170,35 @@ trait MailerAssertionsTrait
      */
     public function getMailerEvent(int $index = 0, ?string $transport = null): ?MessageEvent
     {
-        return $this->getMessageMailerEvents()->getEvents($transport)[$index] ?? null;
+        return $this->getMailerEvents($transport)[$index] ?? null;
+    }
+
+    /**
+     * Returns all sent mailer messages for the given transport.
+     *
+     * ```php
+     * <?php
+     * $messages = $I->getMailerMessages();
+     * ```
+     *
+     * @return RawMessage[]
+     */
+    public function getMailerMessages(?string $transport = null): array
+    {
+        return $this->getMessageMailerEvents()->getMessages($transport);
+    }
+
+    /**
+     * Returns the mailer message at the specified index.
+     *
+     * ```php
+     * <?php
+     * $message = $I->getMailerMessage();
+     * ```
+     */
+    public function getMailerMessage(int $index = 0, ?string $transport = null): ?RawMessage
+    {
+        return $this->getMailerMessages($transport)[$index] ?? null;
     }
 
     protected function grabLastSentRawMessage(): ?RawMessage

--- a/src/Codeception/Module/Symfony/MimeAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MimeAssertionsTrait.php
@@ -11,6 +11,7 @@ use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\RawMessage;
 use Symfony\Component\Mime\Test\Constraint as MimeConstraint;
 
+use function class_exists;
 use function sprintf;
 
 trait MimeAssertionsTrait
@@ -28,6 +29,20 @@ trait MimeAssertionsTrait
     public function assertEmailAddressContains(string $headerName, string $expectedValue, ?Message $email = null): void
     {
         $this->assertThat($this->getMessageOrFail($email, __FUNCTION__), new MimeConstraint\EmailAddressContains($headerName, $expectedValue));
+    }
+
+    /**
+     * Verify that an email does not contain the given address in the specified header.
+     * If no Message is specified, the last sent message is used instead.
+     *
+     * ```php
+     * <?php
+     * $I->assertEmailAddressNotContains('To', 'john_doe@example.com');
+     * ```
+     */
+    public function assertEmailAddressNotContains(string $headerName, string $expectedValue, ?Message $email = null): void
+    {
+        $this->assertThat($this->getMessageOrFail($email, __FUNCTION__), new LogicalNot(new MimeConstraint\EmailAddressContains($headerName, $expectedValue)));
     }
 
     /**
@@ -159,6 +174,36 @@ trait MimeAssertionsTrait
     }
 
     /**
+     * Verify that an email subject contains `$expectedValue`.
+     * If no Email is specified, the last sent email is used instead.
+     *
+     * ```php
+     * <?php
+     * $I->assertEmailSubjectContains('Account created successfully');
+     * ```
+     */
+    public function assertEmailSubjectContains(string $expectedValue, ?Email $email = null): void
+    {
+        $this->assertMimeConstraintAvailable(MimeConstraint\EmailSubjectContains::class, __FUNCTION__);
+        $this->assertThat($this->getMessageOrFail($email, __FUNCTION__), new MimeConstraint\EmailSubjectContains($expectedValue));
+    }
+
+    /**
+     * Verify that an email subject does not contain `$expectedValue`.
+     * If no Email is specified, the last sent email is used instead.
+     *
+     * ```php
+     * <?php
+     * $I->assertEmailSubjectNotContains('Password reset');
+     * ```
+     */
+    public function assertEmailSubjectNotContains(string $expectedValue, ?Email $email = null): void
+    {
+        $this->assertMimeConstraintAvailable(MimeConstraint\EmailSubjectContains::class, __FUNCTION__);
+        $this->assertThat($this->getMessageOrFail($email, __FUNCTION__), new LogicalNot(new MimeConstraint\EmailSubjectContains($expectedValue)));
+    }
+
+    /**
      * Resolves a Message for assertion or fails the test.
      *
      * Uses the provided `$message` or retrieves the last sent message.
@@ -173,5 +218,17 @@ trait MimeAssertionsTrait
         }
 
         return $message;
+    }
+
+    private function assertMimeConstraintAvailable(string $constraintClass, string $function): void
+    {
+        $this->assertTrue(
+            class_exists($constraintClass),
+            sprintf(
+                "The '%s' assertion is not available with your installed symfony/mime version. Missing constraint: %s",
+                $function,
+                $constraintClass
+            )
+        );
     }
 }

--- a/tests/BrowserAssertionsTest.php
+++ b/tests/BrowserAssertionsTest.php
@@ -6,7 +6,11 @@ namespace Tests;
 
 use Codeception\Module\Symfony\BrowserAssertionsTrait;
 use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\BrowserKit\Test\Constraint\BrowserHistoryIsOnFirstPage;
+use Symfony\Component\BrowserKit\Test\Constraint\BrowserHistoryIsOnLastPage;
 use Tests\Support\CodeceptTestCase;
+
+use function class_exists;
 
 final class BrowserAssertionsTest extends CodeceptTestCase
 {
@@ -33,6 +37,50 @@ final class BrowserAssertionsTest extends CodeceptTestCase
     {
         $this->client->getCookieJar()->expire('browser_cookie');
         $this->assertBrowserNotHasCookie('browser_cookie');
+    }
+
+    public function testAssertBrowserHistoryIsOnFirstPage(): void
+    {
+        if (!class_exists(BrowserHistoryIsOnFirstPage::class)) {
+            $this->markTestSkipped('Browser history assertions require symfony/browser-kit with BrowserHistoryIsOnFirstPage support.');
+        }
+
+        $this->client->request('GET', '/');
+        $this->assertBrowserHistoryIsOnFirstPage();
+    }
+
+    public function testAssertBrowserHistoryIsNotOnFirstPage(): void
+    {
+        if (!class_exists(BrowserHistoryIsOnFirstPage::class)) {
+            $this->markTestSkipped('Browser history assertions require symfony/browser-kit with BrowserHistoryIsOnFirstPage support.');
+        }
+
+        $this->client->request('GET', '/');
+        $this->client->request('GET', '/login');
+        $this->assertBrowserHistoryIsNotOnFirstPage();
+    }
+
+    public function testAssertBrowserHistoryIsOnLastPage(): void
+    {
+        if (!class_exists(BrowserHistoryIsOnLastPage::class)) {
+            $this->markTestSkipped('Browser history assertions require symfony/browser-kit with BrowserHistoryIsOnLastPage support.');
+        }
+
+        $this->client->request('GET', '/');
+        $this->client->request('GET', '/login');
+        $this->assertBrowserHistoryIsOnLastPage();
+    }
+
+    public function testAssertBrowserHistoryIsNotOnLastPage(): void
+    {
+        if (!class_exists(BrowserHistoryIsOnLastPage::class)) {
+            $this->markTestSkipped('Browser history assertions require symfony/browser-kit with BrowserHistoryIsOnLastPage support.');
+        }
+
+        $this->client->request('GET', '/');
+        $this->client->request('GET', '/login');
+        $this->client->back();
+        $this->assertBrowserHistoryIsNotOnLastPage();
     }
 
     public function testAssertRequestAttributeValueSame(): void

--- a/tests/DomCrawlerAssertionsTest.php
+++ b/tests/DomCrawlerAssertionsTest.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace Tests;
 
 use Codeception\Module\Symfony\DomCrawlerAssertionsTrait;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerAnySelectorTextContains;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerAnySelectorTextSame;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorCount;
 use Tests\Support\CodeceptTestCase;
+
+use function class_exists;
 
 final class DomCrawlerAssertionsTest extends CodeceptTestCase
 {
@@ -57,14 +62,53 @@ final class DomCrawlerAssertionsTest extends CodeceptTestCase
         $this->assertSelectorNotExists('.non-existent-class', 'This selector should not exist.');
     }
 
+    public function testAssertSelectorCount(): void
+    {
+        if (!class_exists(CrawlerSelectorCount::class)) {
+            $this->markTestSkipped('assertSelectorCount requires CrawlerSelectorCount support in symfony/dom-crawler.');
+        }
+
+        $this->assertSelectorCount(2, 'input', 'Expected exactly 2 inputs on the test page.');
+    }
+
     public function testAssertSelectorTextContains(): void
     {
         $this->assertSelectorTextContains('h1', 'Test', 'The <h1> tag should contain "Test".');
     }
 
+    public function testAssertAnySelectorTextContains(): void
+    {
+        if (!class_exists(CrawlerAnySelectorTextContains::class)) {
+            $this->markTestSkipped('assertAnySelectorTextContains requires CrawlerAnySelectorTextContains support in symfony/dom-crawler.');
+        }
+
+        $this->client->request('GET', '/register');
+        $this->assertAnySelectorTextContains('label', 'Password', 'One label should contain the password text.');
+    }
+
+    public function testAssertAnySelectorTextSame(): void
+    {
+        if (!class_exists(CrawlerAnySelectorTextSame::class)) {
+            $this->markTestSkipped('assertAnySelectorTextSame requires CrawlerAnySelectorTextSame support in symfony/dom-crawler.');
+        }
+
+        $this->client->request('GET', '/register');
+        $this->assertAnySelectorTextSame('label', 'Email Address', 'One label should match the email text.');
+    }
+
     public function testAssertSelectorTextNotContains(): void
     {
         $this->assertSelectorTextNotContains('h1', 'Error', 'The <h1> tag should not contain "Error".');
+    }
+
+    public function testAssertAnySelectorTextNotContains(): void
+    {
+        if (!class_exists(CrawlerAnySelectorTextContains::class)) {
+            $this->markTestSkipped('assertAnySelectorTextNotContains requires CrawlerAnySelectorTextContains support in symfony/dom-crawler.');
+        }
+
+        $this->client->request('GET', '/register');
+        $this->assertAnySelectorTextNotContains('label', 'forbidden_text', 'No label should contain the forbidden text.');
     }
 
     public function testAssertSelectorTextSame(): void

--- a/tests/MailerAssertionsTest.php
+++ b/tests/MailerAssertionsTest.php
@@ -65,6 +65,26 @@ final class MailerAssertionsTest extends CodeceptTestCase
         $this->assertInstanceOf(MessageEvent::class, $this->getMailerEvent());
     }
 
+    public function testGetMailerEvents(): void
+    {
+        $this->client->request('GET', '/send-email');
+        $this->assertCount(1, $this->getMailerEvents());
+    }
+
+    public function testGetMailerMessages(): void
+    {
+        $this->client->request('GET', '/send-email');
+        $messages = $this->getMailerMessages();
+        $this->assertCount(1, $messages);
+        $this->assertInstanceOf(Email::class, $messages[0]);
+    }
+
+    public function testGetMailerMessage(): void
+    {
+        $this->client->request('GET', '/send-email');
+        $this->assertInstanceOf(Email::class, $this->getMailerMessage());
+    }
+
     public function testGrabLastSentEmailReturnsEmailInstance(): void
     {
         $this->client->request('GET', '/send-email');
@@ -113,6 +133,7 @@ final class MailerAssertionsTest extends CodeceptTestCase
 
         $this->client->request('GET', '/send-email');
         $this->assertNull($this->getMailerEvent(999));
+        $this->assertNull($this->getMailerMessage(999));
     }
 
     private function createQueuedEvent(): MessageEvent

--- a/tests/MimeAssertionsTest.php
+++ b/tests/MimeAssertionsTest.php
@@ -11,7 +11,11 @@ use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\Part\TextPart;
+use Symfony\Component\Mime\Test\Constraint\EmailAddressContains;
+use Symfony\Component\Mime\Test\Constraint\EmailSubjectContains;
 use Tests\Support\CodeceptTestCase;
+
+use function class_exists;
 
 final class MimeAssertionsTest extends CodeceptTestCase
 {
@@ -28,6 +32,15 @@ final class MimeAssertionsTest extends CodeceptTestCase
     public function testAssertEmailAddressContains(): void
     {
         $this->assertEmailAddressContains('To', 'jane_doe@example.com');
+    }
+
+    public function testAssertEmailAddressNotContains(): void
+    {
+        if (!class_exists(EmailAddressContains::class)) {
+            $this->markTestSkipped('assertEmailAddressNotContains requires EmailAddressContains support in symfony/mime.');
+        }
+
+        $this->assertEmailAddressNotContains('To', 'john_doe@example.com');
     }
 
     public function testAssertEmailAttachmentCount(): void
@@ -75,12 +88,45 @@ final class MimeAssertionsTest extends CodeceptTestCase
         $this->assertEmailTextBodyNotContains('My secret text body');
     }
 
+    public function testAssertEmailSubjectContains(): void
+    {
+        if (!class_exists(EmailSubjectContains::class)) {
+            $this->markTestSkipped('assertEmailSubjectContains requires EmailSubjectContains support in symfony/mime.');
+        }
+
+        $this->assertEmailSubjectContains('Account created successfully');
+    }
+
+    public function testAssertEmailSubjectNotContains(): void
+    {
+        if (!class_exists(EmailSubjectContains::class)) {
+            $this->markTestSkipped('assertEmailSubjectNotContains requires EmailSubjectContains support in symfony/mime.');
+        }
+
+        $this->assertEmailSubjectNotContains('Password reset');
+    }
+
     public function testAssertionsWorkWithProvidedEmail(): void
     {
-        $email = (new Email())->from('custom@example.com')->to('custom@example.com')->text('Custom body text');
+        if (!class_exists(EmailAddressContains::class)) {
+            $this->markTestSkipped('assertEmailAddressNotContains requires EmailAddressContains support in symfony/mime.');
+        }
+
+        if (!class_exists(EmailSubjectContains::class)) {
+            $this->markTestSkipped('assertEmailSubjectContains/assertEmailSubjectNotContains require EmailSubjectContains support in symfony/mime.');
+        }
+
+        $email = (new Email())
+            ->from('custom@example.com')
+            ->to('custom@example.com')
+            ->subject('Custom subject')
+            ->text('Custom body text');
 
         $this->assertEmailAddressContains('To', 'custom@example.com', $email);
+        $this->assertEmailAddressNotContains('To', 'other@example.com', $email);
         $this->assertEmailTextBodyContains('Custom body text', $email);
+        $this->assertEmailSubjectContains('Custom subject', $email);
+        $this->assertEmailSubjectNotContains('Other subject', $email);
         $this->assertEmailNotHasHeader('Cc', $email);
     }
 


### PR DESCRIPTION
## What

Adds assertion/getter methods that mirror Symfony's own test API, in the matching module traits. These belong to the `assert*` / `get*` family of the naming convention documented in `CONTRIBUTING.md`: direct value/constraint comparisons that map closely to PHPUnit/Symfony assertion semantics.

### Methods

- **BrowserAssertionsTrait**: `assertBrowserHistoryIsOnFirstPage`, `assertBrowserHistoryIsNotOnFirstPage`, `assertBrowserHistoryIsOnLastPage`, `assertBrowserHistoryIsNotOnLastPage` (wrap `symfony/browser-kit` constraints)
- **DomCrawlerAssertionsTrait**: `assertSelectorCount`, `assertAnySelectorTextContains`, `assertAnySelectorTextSame`, `assertAnySelectorTextNotContains`
- **MailerAssertionsTrait**: `getMailerEvents`, `getMailerMessages`, `getMailerMessage`
- **MimeAssertionsTrait**: `assertEmailAddressNotContains`, `assertEmailSubjectContains`, `assertEmailSubjectNotContains`

Each method is guarded for the Symfony component version that introduced the underlying constraint.

## Tests

Unit tests added for every method (`tests/BrowserAssertionsTest`, `DomCrawlerAssertionsTest`, `MailerAssertionsTest`, `MimeAssertionsTest`).

## Notes

Split out from the original "new assertions" change. This PR contains **only** the Symfony-mirroring assertions; the module-specific `see*` / `dontSee*` assertions (Doctrine, Environment, Security, Session) are in companion PR #218, for clear separation of responsibilities.
