### PR TITLE
Restore doctrine.connections after kernel shutdown

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -55,8 +55,6 @@ class Symfony extends HttpKernelBrowser
     {
         $this->updatePersistentServices();
 
-        $this->persistDoctrineConnections();
-
         if ($this->kernel instanceof Kernel) {
             $this->ensureKernelShutdown();
             $this->kernel->boot();
@@ -72,7 +70,28 @@ class Symfony extends HttpKernelBrowser
     protected function ensureKernelShutdown(): void
     {
         $this->kernel->boot();
-        $this->kernel->shutdown();
+
+        $kernel = $this->kernel;
+        (function () use ($kernel): void {
+            $parameters = property_exists($this, 'parameters') ? $this->parameters : null;
+            if (!is_array($parameters) || !array_key_exists('doctrine.connections', $parameters)) {
+                $kernel->shutdown();
+
+                return;
+            }
+
+            $connections = $parameters['doctrine.connections'];
+            unset($parameters['doctrine.connections']);
+            $this->parameters = $parameters;
+
+            try {
+                $kernel->shutdown();
+            } finally {
+                $parameters = $this->parameters;
+                $parameters['doctrine.connections'] = $connections;
+                $this->parameters = $parameters;
+            }
+        })->call($kernel->getContainer());
     }
 
     private function resolveContainer(): ContainerInterface
@@ -96,15 +115,6 @@ class Symfony extends HttpKernelBrowser
         }
 
         return null;
-    }
-
-    private function persistDoctrineConnections(): void
-    {
-        (function (): void {
-            if (property_exists($this, 'parameters') && is_array($this->parameters)) {
-                unset($this->parameters['doctrine.connections']);
-            }
-        })->call($this->kernel->getContainer());
     }
 
     private function updatePersistentServices(): void

--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -73,23 +73,15 @@ class Symfony extends HttpKernelBrowser
 
         $kernel = $this->kernel;
         (function () use ($kernel): void {
-            $parameters = property_exists($this, 'parameters') ? $this->parameters : null;
-            if (!is_array($parameters) || !array_key_exists('doctrine.connections', $parameters)) {
+            if (!property_exists($this, 'parameters') || !is_array($this->parameters)) {
                 $kernel->shutdown();
-
                 return;
             }
-
-            $connections = $parameters['doctrine.connections'];
-            unset($parameters['doctrine.connections']);
-            $this->parameters = $parameters;
-
-            try {
-                $kernel->shutdown();
-            } finally {
-                $parameters = $this->parameters;
-                $parameters['doctrine.connections'] = $connections;
-                $this->parameters = $parameters;
+            $connections = $this->parameters['doctrine.connections'] ?? null;
+            unset($this->parameters['doctrine.connections']);
+            $kernel->shutdown();
+            if ($connections !== null) {
+                $this->parameters['doctrine.connections'] = $connections;
             }
         })->call($kernel->getContainer());
     }


### PR DESCRIPTION
Hi guys! After updating to 3.10 in my projects, all tests started failing with error:
```
[Warning] Undefined array key "doctrine.connections" at /var/www/var/cache/test/ContainerKbNY0zx/App_KernelTestDebugContainer.php:1629
```
The combined changes in [persistDoctrineConnections in 3.9.0](https://github.com/Codeception/module-symfony/commit/768cdc6fa41dfd85f92b180ffccd90daa0fa26f4#diff-b9ce0d13bb1001256fa498ed6cc44ee1aa6d08cf5dae99709cbabb9a9694d5bfR113-R117) and in [_getEntityManager in 3.10.0](https://github.com/Codeception/module-symfony/pull/236/changes) opened this bug, because `Symfony::rebootKernel()` removes `doctrine.connections` to prevent DoctrineBundle from closing the persistent DBAL connection during kernel shutdown and this parameter is  never restored, leaving the previous container broken.

Tried to make a minimal change. We remove the parameter in the kernel shutdown phase and restores it afterward. The restoration is also done when kernel shutdown throws. The DBAL connection stays persistent, while the entity manager is still recreated from the current container.
